### PR TITLE
Fixed value mapping for HH3C

### DIFF
--- a/in/template_net_hp_hh3c.yaml
+++ b/in/template_net_hp_hh3c.yaml
@@ -184,29 +184,29 @@ value_maps:
         newvalue: postFailure
       - value: "4"
         newvalue: entityAbsent
-      - value: "5"
-        newvalue: poeError
-      - value: "6"
-        newvalue: stackError
-      - value: "7"
-        newvalue: stackPortBlocked
-      - value: "8"
-        newvalue: stackPortFailed
-      - value: "9"
-        newvalue: sfpRecvError
-      - value: "10"
-        newvalue: sfpSendError
       - value: "11"
+        newvalue: poeError
+      - value: "21"
+        newvalue: stackError
+      - value: "22"
+        newvalue: stackPortBlocked
+      - value: "23"
+        newvalue: stackPortFailed
+      - value: "31"
+        newvalue: sfpRecvError
+      - value: "32"
+        newvalue: sfpSendError
+      - value: "33"
         newvalue: sfpBothError
-      - value: "12"
+      - value: "41"
         newvalue: fanError
-      - value: "13"
+      - value: "51"
         newvalue: psuError
-      - value: "14"
+      - value: "61"
         newvalue: rpsError
-      - value: "15"
+      - value: "71"
         newvalue: moduleFaulty
-      - value: "16"
+      - value: "81"
         newvalue: sensorError
-      - value: "17"
+      - value: "91"
         newvalue: hardwareFaulty


### PR DESCRIPTION
Based on official HPE MIB files and also some public references, like http://www.circitor.fr/Mibs/Html/H/HH3C-ENTITY-EXT-MIB.php#hh3cEntityExtErrorStatus the value mapping should be as proposed.