### PR TITLE
cisco: Changed poll time of CPU metrics to 5m by default

### DIFF
--- a/in/template_net_cisco.json
+++ b/in/template_net_cisco.json
@@ -67,6 +67,7 @@
                     "items": [
                         {
                             "_prototype": "system.cpu.util",
+                            "update": "5m",
                             "oid": "1.3.6.1.4.1.9.9.109.1.1.1.1.8.{#SNMPINDEX}",
                             "_snmpObject": "cpmCPUTotal5minRev.{#SNMPINDEX}",
                             "_mib": "CISCO-PROCESS-MIB",
@@ -95,6 +96,7 @@
                         {
                             "_prototype": "system.cpu.util",
                             "oid": "1.3.6.1.4.1.9.9.109.1.1.1.1.5.{#SNMPINDEX}",
+                            "update": "5m",
                             "_snmpObject": "cpmCPUTotal5min.{#SNMPINDEX}",
                             "_mib": "CISCO-PROCESS-MIB",
                             "_ref": "http://www.cisco.com/c/en/us/support/docs/ip/simple-network-management-protocol-snmp/15215-collect-cpu-util-snmp.html",
@@ -115,6 +117,7 @@
             "items": [
                 {
                     "_prototype": "system.cpu.util",
+                    "update": "5m",
                     "oid": "1.3.6.1.4.1.9.2.1.58",
                     "_snmpObject": "avgBusy5",
                     "_mib": "OLD-CISCO-CPU-MIB",

--- a/out/3.2/EN/net/cisco_snmpv2/template_net_cisco_snmpv2.xml
+++ b/out/3.2/EN/net/cisco_snmpv2/template_net_cisco_snmpv2.xml
@@ -333,7 +333,7 @@ In case of a single CPU, cpmCPUTotalTable has only one entry.</description>
                      <multiplier>0</multiplier>
                      <snmp_oid>1.3.6.1.4.1.9.9.109.1.1.1.1.8.{#SNMPINDEX}</snmp_oid>
                      <key>system.cpu.util[cpmCPUTotal5minRev.{#SNMPINDEX}]</key>
-                     <delay>60</delay>
+                     <delay>300</delay>
                      <history>7</history>
                      <trends>365</trends>
                      <status>0</status>
@@ -503,7 +503,7 @@ In case of a single CPU, cpmCPUTotalTable has only one entry.</description>
                      <multiplier>0</multiplier>
                      <snmp_oid>1.3.6.1.4.1.9.9.109.1.1.1.1.5.{#SNMPINDEX}</snmp_oid>
                      <key>system.cpu.util[cpmCPUTotal5min.{#SNMPINDEX}]</key>
-                     <delay>60</delay>
+                     <delay>300</delay>
                      <history>7</history>
                      <trends>365</trends>
                      <status>0</status>
@@ -639,7 +639,7 @@ Template tooling version used: 0.33</description>
                <multiplier>0</multiplier>
                <snmp_oid>1.3.6.1.4.1.9.2.1.58</snmp_oid>
                <key>system.cpu.util[avgBusy5]</key>
-               <delay>60</delay>
+               <delay>300</delay>
                <history>7</history>
                <trends>365</trends>
                <status>0</status>

--- a/out/3.2/RU/net/cisco_snmpv2/template_net_cisco_snmpv2.xml
+++ b/out/3.2/RU/net/cisco_snmpv2/template_net_cisco_snmpv2.xml
@@ -333,7 +333,7 @@ In case of a single CPU, cpmCPUTotalTable has only one entry.</description>
                      <multiplier>0</multiplier>
                      <snmp_oid>1.3.6.1.4.1.9.9.109.1.1.1.1.8.{#SNMPINDEX}</snmp_oid>
                      <key>system.cpu.util[cpmCPUTotal5minRev.{#SNMPINDEX}]</key>
-                     <delay>60</delay>
+                     <delay>300</delay>
                      <history>7</history>
                      <trends>365</trends>
                      <status>0</status>
@@ -503,7 +503,7 @@ In case of a single CPU, cpmCPUTotalTable has only one entry.</description>
                      <multiplier>0</multiplier>
                      <snmp_oid>1.3.6.1.4.1.9.9.109.1.1.1.1.5.{#SNMPINDEX}</snmp_oid>
                      <key>system.cpu.util[cpmCPUTotal5min.{#SNMPINDEX}]</key>
-                     <delay>60</delay>
+                     <delay>300</delay>
                      <history>7</history>
                      <trends>365</trends>
                      <status>0</status>
@@ -639,7 +639,7 @@ Template tooling version used: 0.33</description>
                <multiplier>0</multiplier>
                <snmp_oid>1.3.6.1.4.1.9.2.1.58</snmp_oid>
                <key>system.cpu.util[avgBusy5]</key>
-               <delay>60</delay>
+               <delay>300</delay>
                <history>7</history>
                <trends>365</trends>
                <status>0</status>

--- a/out/3.4/EN/net/cisco_snmpv2/template_net_cisco_snmpv2.xml
+++ b/out/3.4/EN/net/cisco_snmpv2/template_net_cisco_snmpv2.xml
@@ -326,7 +326,7 @@ In case of a single CPU, cpmCPUTotalTable has only one entry.</description>
                      <snmp_community>{$SNMP_COMMUNITY}</snmp_community>
                      <snmp_oid>1.3.6.1.4.1.9.9.109.1.1.1.1.8.{#SNMPINDEX}</snmp_oid>
                      <key>system.cpu.util[cpmCPUTotal5minRev.{#SNMPINDEX}]</key>
-                     <delay>1m</delay>
+                     <delay>5m</delay>
                      <history>7d</history>
                      <trends>365d</trends>
                      <status>0</status>
@@ -495,7 +495,7 @@ In case of a single CPU, cpmCPUTotalTable has only one entry.</description>
                      <snmp_community>{$SNMP_COMMUNITY}</snmp_community>
                      <snmp_oid>1.3.6.1.4.1.9.9.109.1.1.1.1.5.{#SNMPINDEX}</snmp_oid>
                      <key>system.cpu.util[cpmCPUTotal5min.{#SNMPINDEX}]</key>
-                     <delay>1m</delay>
+                     <delay>5m</delay>
                      <history>7d</history>
                      <trends>365d</trends>
                      <status>0</status>
@@ -631,7 +631,7 @@ Template tooling version used: 0.33</description>
                <snmp_community>{$SNMP_COMMUNITY}</snmp_community>
                <snmp_oid>1.3.6.1.4.1.9.2.1.58</snmp_oid>
                <key>system.cpu.util[avgBusy5]</key>
-               <delay>1m</delay>
+               <delay>5m</delay>
                <history>7d</history>
                <trends>365d</trends>
                <status>0</status>

--- a/out/3.4/RU/net/cisco_snmpv2/template_net_cisco_snmpv2.xml
+++ b/out/3.4/RU/net/cisco_snmpv2/template_net_cisco_snmpv2.xml
@@ -326,7 +326,7 @@ In case of a single CPU, cpmCPUTotalTable has only one entry.</description>
                      <snmp_community>{$SNMP_COMMUNITY}</snmp_community>
                      <snmp_oid>1.3.6.1.4.1.9.9.109.1.1.1.1.8.{#SNMPINDEX}</snmp_oid>
                      <key>system.cpu.util[cpmCPUTotal5minRev.{#SNMPINDEX}]</key>
-                     <delay>1m</delay>
+                     <delay>5m</delay>
                      <history>7d</history>
                      <trends>365d</trends>
                      <status>0</status>
@@ -495,7 +495,7 @@ In case of a single CPU, cpmCPUTotalTable has only one entry.</description>
                      <snmp_community>{$SNMP_COMMUNITY}</snmp_community>
                      <snmp_oid>1.3.6.1.4.1.9.9.109.1.1.1.1.5.{#SNMPINDEX}</snmp_oid>
                      <key>system.cpu.util[cpmCPUTotal5min.{#SNMPINDEX}]</key>
-                     <delay>1m</delay>
+                     <delay>5m</delay>
                      <history>7d</history>
                      <trends>365d</trends>
                      <status>0</status>
@@ -631,7 +631,7 @@ Template tooling version used: 0.33</description>
                <snmp_community>{$SNMP_COMMUNITY}</snmp_community>
                <snmp_oid>1.3.6.1.4.1.9.2.1.58</snmp_oid>
                <key>system.cpu.util[avgBusy5]</key>
-               <delay>1m</delay>
+               <delay>5m</delay>
                <history>7d</history>
                <trends>365d</trends>
                <status>0</status>

--- a/out/4.0/EN/net/cisco_snmpv2/template_net_cisco_snmpv2.xml
+++ b/out/4.0/EN/net/cisco_snmpv2/template_net_cisco_snmpv2.xml
@@ -397,7 +397,7 @@ In case of a single CPU, cpmCPUTotalTable has only one entry.</description>
                      <snmp_community>{$SNMP_COMMUNITY}</snmp_community>
                      <snmp_oid>1.3.6.1.4.1.9.9.109.1.1.1.1.8.{#SNMPINDEX}</snmp_oid>
                      <key>system.cpu.util[cpmCPUTotal5minRev.{#SNMPINDEX}]</key>
-                     <delay>1m</delay>
+                     <delay>5m</delay>
                      <history>7d</history>
                      <trends>365d</trends>
                      <status>0</status>
@@ -601,7 +601,7 @@ In case of a single CPU, cpmCPUTotalTable has only one entry.</description>
                      <snmp_community>{$SNMP_COMMUNITY}</snmp_community>
                      <snmp_oid>1.3.6.1.4.1.9.9.109.1.1.1.1.5.{#SNMPINDEX}</snmp_oid>
                      <key>system.cpu.util[cpmCPUTotal5min.{#SNMPINDEX}]</key>
-                     <delay>1m</delay>
+                     <delay>5m</delay>
                      <history>7d</history>
                      <trends>365d</trends>
                      <status>0</status>
@@ -772,7 +772,7 @@ Template tooling version used: 0.33</description>
                <snmp_community>{$SNMP_COMMUNITY}</snmp_community>
                <snmp_oid>1.3.6.1.4.1.9.2.1.58</snmp_oid>
                <key>system.cpu.util[avgBusy5]</key>
-               <delay>1m</delay>
+               <delay>5m</delay>
                <history>7d</history>
                <trends>365d</trends>
                <status>0</status>

--- a/out/4.0/RU/net/cisco_snmpv2/template_net_cisco_snmpv2.xml
+++ b/out/4.0/RU/net/cisco_snmpv2/template_net_cisco_snmpv2.xml
@@ -397,7 +397,7 @@ In case of a single CPU, cpmCPUTotalTable has only one entry.</description>
                      <snmp_community>{$SNMP_COMMUNITY}</snmp_community>
                      <snmp_oid>1.3.6.1.4.1.9.9.109.1.1.1.1.8.{#SNMPINDEX}</snmp_oid>
                      <key>system.cpu.util[cpmCPUTotal5minRev.{#SNMPINDEX}]</key>
-                     <delay>1m</delay>
+                     <delay>5m</delay>
                      <history>7d</history>
                      <trends>365d</trends>
                      <status>0</status>
@@ -601,7 +601,7 @@ In case of a single CPU, cpmCPUTotalTable has only one entry.</description>
                      <snmp_community>{$SNMP_COMMUNITY}</snmp_community>
                      <snmp_oid>1.3.6.1.4.1.9.9.109.1.1.1.1.5.{#SNMPINDEX}</snmp_oid>
                      <key>system.cpu.util[cpmCPUTotal5min.{#SNMPINDEX}]</key>
-                     <delay>1m</delay>
+                     <delay>5m</delay>
                      <history>7d</history>
                      <trends>365d</trends>
                      <status>0</status>
@@ -772,7 +772,7 @@ Template tooling version used: 0.33</description>
                <snmp_community>{$SNMP_COMMUNITY}</snmp_community>
                <snmp_oid>1.3.6.1.4.1.9.2.1.58</snmp_oid>
                <key>system.cpu.util[avgBusy5]</key>
-               <delay>1m</delay>
+               <delay>5m</delay>
                <history>7d</history>
                <trends>365d</trends>
                <status>0</status>

--- a/out/4.2/EN/net/cisco_snmpv2/template_net_cisco_snmpv2.xml
+++ b/out/4.2/EN/net/cisco_snmpv2/template_net_cisco_snmpv2.xml
@@ -401,7 +401,7 @@ In case of a single CPU, cpmCPUTotalTable has only one entry.</description>
                      <snmp_community>{$SNMP_COMMUNITY}</snmp_community>
                      <snmp_oid>1.3.6.1.4.1.9.9.109.1.1.1.1.8.{#SNMPINDEX}</snmp_oid>
                      <key>system.cpu.util[cpmCPUTotal5minRev.{#SNMPINDEX}]</key>
-                     <delay>1m</delay>
+                     <delay>5m</delay>
                      <history>7d</history>
                      <trends>365d</trends>
                      <status>0</status>
@@ -609,7 +609,7 @@ In case of a single CPU, cpmCPUTotalTable has only one entry.</description>
                      <snmp_community>{$SNMP_COMMUNITY}</snmp_community>
                      <snmp_oid>1.3.6.1.4.1.9.9.109.1.1.1.1.5.{#SNMPINDEX}</snmp_oid>
                      <key>system.cpu.util[cpmCPUTotal5min.{#SNMPINDEX}]</key>
-                     <delay>1m</delay>
+                     <delay>5m</delay>
                      <history>7d</history>
                      <trends>365d</trends>
                      <status>0</status>
@@ -784,7 +784,7 @@ Template tooling version used: 0.33</description>
                <snmp_community>{$SNMP_COMMUNITY}</snmp_community>
                <snmp_oid>1.3.6.1.4.1.9.2.1.58</snmp_oid>
                <key>system.cpu.util[avgBusy5]</key>
-               <delay>1m</delay>
+               <delay>5m</delay>
                <history>7d</history>
                <trends>365d</trends>
                <status>0</status>

--- a/out/4.2/RU/net/cisco_snmpv2/template_net_cisco_snmpv2.xml
+++ b/out/4.2/RU/net/cisco_snmpv2/template_net_cisco_snmpv2.xml
@@ -401,7 +401,7 @@ In case of a single CPU, cpmCPUTotalTable has only one entry.</description>
                      <snmp_community>{$SNMP_COMMUNITY}</snmp_community>
                      <snmp_oid>1.3.6.1.4.1.9.9.109.1.1.1.1.8.{#SNMPINDEX}</snmp_oid>
                      <key>system.cpu.util[cpmCPUTotal5minRev.{#SNMPINDEX}]</key>
-                     <delay>1m</delay>
+                     <delay>5m</delay>
                      <history>7d</history>
                      <trends>365d</trends>
                      <status>0</status>
@@ -609,7 +609,7 @@ In case of a single CPU, cpmCPUTotalTable has only one entry.</description>
                      <snmp_community>{$SNMP_COMMUNITY}</snmp_community>
                      <snmp_oid>1.3.6.1.4.1.9.9.109.1.1.1.1.5.{#SNMPINDEX}</snmp_oid>
                      <key>system.cpu.util[cpmCPUTotal5min.{#SNMPINDEX}]</key>
-                     <delay>1m</delay>
+                     <delay>5m</delay>
                      <history>7d</history>
                      <trends>365d</trends>
                      <status>0</status>
@@ -784,7 +784,7 @@ Template tooling version used: 0.33</description>
                <snmp_community>{$SNMP_COMMUNITY}</snmp_community>
                <snmp_oid>1.3.6.1.4.1.9.2.1.58</snmp_oid>
                <key>system.cpu.util[avgBusy5]</key>
-               <delay>1m</delay>
+               <delay>5m</delay>
                <history>7d</history>
                <trends>365d</trends>
                <status>0</status>

--- a/out/4.4/EN/net/cisco_snmpv2/template_net_cisco_snmpv2.xml
+++ b/out/4.4/EN/net/cisco_snmpv2/template_net_cisco_snmpv2.xml
@@ -458,6 +458,7 @@ In case of a single CPU, cpmCPUTotalTable has only one entry.</description>
                      <snmp_community>{$SNMP_COMMUNITY}</snmp_community>
                      <snmp_oid>1.3.6.1.4.1.9.9.109.1.1.1.1.5.{#SNMPINDEX}</snmp_oid>
                      <key>system.cpu.util[cpmCPUTotal5min.{#SNMPINDEX}]</key>
+                     <delay>5m</delay>
                      <history>7d</history>
                      <value_type>FLOAT</value_type>
                      <units>%</units>
@@ -549,6 +550,7 @@ In case of a single CPU, cpmCPUTotalTable has only one entry.</description>
                      <snmp_community>{$SNMP_COMMUNITY}</snmp_community>
                      <snmp_oid>1.3.6.1.4.1.9.9.109.1.1.1.1.8.{#SNMPINDEX}</snmp_oid>
                      <key>system.cpu.util[cpmCPUTotal5minRev.{#SNMPINDEX}]</key>
+                     <delay>5m</delay>
                      <history>7d</history>
                      <value_type>FLOAT</value_type>
                      <units>%</units>
@@ -803,6 +805,7 @@ Template tooling version used: 0.33</description>
                <snmp_community>{$SNMP_COMMUNITY}</snmp_community>
                <snmp_oid>1.3.6.1.4.1.9.2.1.58</snmp_oid>
                <key>system.cpu.util[avgBusy5]</key>
+               <delay>5m</delay>
                <history>7d</history>
                <value_type>FLOAT</value_type>
                <units>%</units>

--- a/out/4.4/RU/net/cisco_snmpv2/template_net_cisco_snmpv2.xml
+++ b/out/4.4/RU/net/cisco_snmpv2/template_net_cisco_snmpv2.xml
@@ -458,6 +458,7 @@ In case of a single CPU, cpmCPUTotalTable has only one entry.</description>
                      <snmp_community>{$SNMP_COMMUNITY}</snmp_community>
                      <snmp_oid>1.3.6.1.4.1.9.9.109.1.1.1.1.5.{#SNMPINDEX}</snmp_oid>
                      <key>system.cpu.util[cpmCPUTotal5min.{#SNMPINDEX}]</key>
+                     <delay>5m</delay>
                      <history>7d</history>
                      <value_type>FLOAT</value_type>
                      <units>%</units>
@@ -549,6 +550,7 @@ In case of a single CPU, cpmCPUTotalTable has only one entry.</description>
                      <snmp_community>{$SNMP_COMMUNITY}</snmp_community>
                      <snmp_oid>1.3.6.1.4.1.9.9.109.1.1.1.1.8.{#SNMPINDEX}</snmp_oid>
                      <key>system.cpu.util[cpmCPUTotal5minRev.{#SNMPINDEX}]</key>
+                     <delay>5m</delay>
                      <history>7d</history>
                      <value_type>FLOAT</value_type>
                      <units>%</units>
@@ -803,6 +805,7 @@ Template tooling version used: 0.33</description>
                <snmp_community>{$SNMP_COMMUNITY}</snmp_community>
                <snmp_oid>1.3.6.1.4.1.9.2.1.58</snmp_oid>
                <key>system.cpu.util[avgBusy5]</key>
+               <delay>5m</delay>
                <history>7d</history>
                <value_type>FLOAT</value_type>
                <units>%</units>


### PR DESCRIPTION
Fixes #5 