### PR TITLE
this pr for hpe servers adds much more details and status

### DIFF
--- a/out/5.0/EN/server/hp_ilo_snmpv2/template_server_hp_ilo_snmpv2.xml
+++ b/out/5.0/EN/server/hp_ilo_snmpv2/template_server_hp_ilo_snmpv2.xml
@@ -1,207 +1,615 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <zabbix_export>
-   <version>5.0</version>
-   <date>2020-03-19T10:55:02Z</date>
-   <groups>
-      <group>
-         <name>Templates/Server hardware</name>
-      </group>
-   </groups>
-   <templates>
-      <template>
-         <template>Template Server HP iLO SNMPv2</template>
-         <name>Template Server HP iLO SNMPv2</name>
-         <description>Template Server HP iLO&#13;
+    <version>5.0</version>
+    <date>2020-07-07T21:44:18Z</date>
+    <groups>
+        <group>
+            <name>Templates/Server hardware</name>
+        </group>
+    </groups>
+    <templates>
+        <template>
+            <template>Template Server HP iLO SNMPv2</template>
+            <name>Template Server HP iLO SNMPv2</name>
+            <description>Template Server HP iLO version: 0.15&#13;
 &#13;
+Overview: for HP iLO adapters that support SNMP get. Or via operating system, using SNMP HP subagent&#13;
 MIBs used:&#13;
+&#13;
 CPQSINFO-MIB&#13;
 CPQHLTH-MIB&#13;
+CPQHOST-MIB&#13;
 CPQIDA-MIB&#13;
 &#13;
-Template tooling version used: 0.35</description>
-         <templates>
-            <template>
-               <name>Template Module Generic SNMPv2</name>
-            </template>
-         </templates>
-         <groups>
-            <group>
-               <name>Templates/Server hardware</name>
-            </group>
-         </groups>
-         <applications>
-            <application>
-               <name>Disk arrays</name>
-            </application>
-            <application>
-               <name>Fans</name>
-            </application>
-            <application>
-               <name>Inventory</name>
-            </application>
-            <application>
-               <name>Physical disks</name>
-            </application>
-            <application>
-               <name>Power supply</name>
-            </application>
-            <application>
-               <name>Status</name>
-            </application>
-            <application>
-               <name>Temperature</name>
-            </application>
-            <application>
-               <name>Virtual disks</name>
-            </application>
-         </applications>
-         <items>
-            <item>
-               <name>System: Temperature status</name>
-               <type>SNMPV2</type>
-               <snmp_community>{$SNMP_COMMUNITY}</snmp_community>
-               <snmp_oid>1.3.6.1.4.1.232.6.2.6.1.0</snmp_oid>
-               <key>sensor.temp.status[cpqHeThermalCondition.0]</key>
-               <delay>3m</delay>
-               <history>2w</history>
-               <trends>0d</trends>
-               <description>MIB: CPQHLTH-MIB&#13;
+Important: &#13;
+&#13;
+Please set the macro {#TEMP_WARN} in Celsius so that you may be alerted when the temperature is nearing the mgf warning threshold. For example, the default of 3°C will warn you when the temperature is within 3°C of the warning threshold.&#13;
+&#13;
+If you want this disabled then leave it set at 0</description>
+            <templates>
+                <template>
+                   <name>Template Module Generic SNMPv2</name>
+                </template>
+                <template>
+                    <name>Template Module Interfaces SNMPv2</name>
+                </template>
+            </templates>
+            <groups>
+                <group>
+                    <name>Templates/Server hardware</name>
+                </group>
+            </groups>
+            <applications>
+                <application>
+                    <name>Disk Arrays</name>
+                </application>
+                <application>
+                    <name>Fans</name>
+                </application>
+                <application>
+                    <name>Firmware</name>
+                </application>
+                <application>
+                    <name>Inventory</name>
+                </application>
+                <application>
+                    <name>Memory</name>
+                </application>
+                <application>
+                    <name>Physical Disks</name>
+                </application>
+                <application>
+                    <name>Power Supply</name>
+                </application>
+                <application>
+                    <name>Status</name>
+                </application>
+                <application>
+                    <name>Temperature</name>
+                </application>
+                <application>
+                    <name>Virtual Disks</name>
+                </application>
+            </applications>
+            <items>
+                <item>
+                    <name>System: Temperature status</name>
+                    <type>SNMP_AGENT</type>
+                    <snmp_oid>1.3.6.1.4.1.232.6.2.6.1.0</snmp_oid>
+                    <key>sensor.temp.status[cpqHeThermalCondition.0]</key>
+                    <delay>3m</delay>
+                    <history>2w</history>
+                    <trends>0d</trends>
+                    <description>MIB: CPQHLTH-MIB&#13;
 This value specifies the overall condition of the system's thermal environment.&#13;
 This value will be one of the following:&#13;
 other(1)  Temperature could not be determined.&#13;
 ok(2)  The temperature sensor is within normal operating range.&#13;
 degraded(3)  The temperature sensor is outside of normal operating range.&#13;
 failed(4)  The temperature sensor detects a condition that could  permanently damage the system.</description>
-               <applications>
-                  <application>
-                     <name>Temperature</name>
-                  </application>
-               </applications>
-               <valuemap>
-                  <name>CPQSINFO-MIB::status</name>
-               </valuemap>
-            </item>
-            <item>
-               <name>Hardware model name</name>
-               <type>SNMPV2</type>
-               <snmp_community>{$SNMP_COMMUNITY}</snmp_community>
-               <snmp_oid>1.3.6.1.4.1.232.2.2.4.2.0</snmp_oid>
-               <key>system.hw.model</key>
-               <delay>1h</delay>
-               <history>2w</history>
-               <trends>0</trends>
-               <value_type>CHAR</value_type>
-               <description>MIB: CPQSINFO-MIB&#13;
+                    <applications>
+                        <application>
+                            <name>Inventory</name>
+                        </application>
+                        <application>
+                            <name>Temperature</name>
+                        </application>
+                    </applications>
+                    <valuemap>
+                        <name>CPQSINFO-MIB::status</name>
+                    </valuemap>
+                </item>
+                <item>
+                    <name>System: OS Description</name>
+                    <type>SNMP_AGENT</type>
+                    <snmp_oid>1.3.6.1.4.1.232.11.2.2.3.0</snmp_oid>
+                    <key>system.host.osDesc[cpqHoDesc.0]</key>
+                    <delay>1d</delay>
+                    <history>2w</history>
+                    <trends>0</trends>
+                    <value_type>TEXT</value_type>
+                    <description>CPQHOST-MIB::cpqHoDesc&#13;
+A further description of the host OS.</description>
+                    <inventory_link>OS</inventory_link>
+                    <applications>
+                        <application>
+                            <name>Inventory</name>
+                        </application>
+                    </applications>
+                </item>
+                <item>
+                    <name>System: OS Name</name>
+                    <type>SNMP_AGENT</type>
+                    <snmp_oid>1.3.6.1.4.1.232.11.2.2.1.0</snmp_oid>
+                    <key>system.host.osName[cpqHoName.0]</key>
+                    <delay>1d</delay>
+                    <history>2w</history>
+                    <trends>0</trends>
+                    <value_type>TEXT</value_type>
+                    <description>CPQHOST-MIB::cpqHoName&#13;
+The name of the host operating system (OS).</description>
+                    <applications>
+                        <application>
+                            <name>Inventory</name>
+                        </application>
+                    </applications>
+                </item>
+                <item>
+                    <name>System: OS Type</name>
+                    <type>SNMP_AGENT</type>
+                    <snmp_oid>1.3.6.1.4.1.232.11.2.2.4.0</snmp_oid>
+                    <key>system.host.osType[cpqHoOsType.0]</key>
+                    <delay>1d</delay>
+                    <history>2w</history>
+                    <trends>0d</trends>
+                    <description>CPQHOST-MIB::cpqHoOsType&#13;
+            other(1),&#13;
+            netware(2),                -- Novell NetWare&#13;
+            windowsnt(3),              -- Microsoft Windows NT&#13;
+            sco-unix(4),               -- SCO OpenServer&#13;
+            unixware(5),               -- SCO UnixWare&#13;
+            os-2(6),                   -- IBM OS/2&#13;
+            ms-dos(7),                 -- Microsoft DOS&#13;
+            dos-windows(8),            -- Microsoft DOS + Microsoft Windows&#13;
+            windows95(9),              -- Microsoft Windows 95&#13;
+            windows98(10),             -- Microsoft Windows 98&#13;
+            open-vms(11),              -- Open VMS&#13;
+            nsk(12),                   -- Non Stop Kernel&#13;
+            windowsCE(13),             -- Microsoft Windows CE&#13;
+            linux(14),                 -- Linux&#13;
+            windows2000(15),           -- Microsoft Windows 2000&#13;
+            tru64UNIX(16),             -- Tru64 UNIX&#13;
+            windows2003(17),           -- Microsoft Windows Server 2003&#13;
+            windows2003-x64(18),       -- Microsoft Windows Server 2003 x64 Edition&#13;
+            solaris(19),               -- Sun Solaris &#13;
+            windows2003-ia64(20),      -- Microsoft Windows Server 2003 for Itanium-based Systems&#13;
+            windows2008(21),           -- Microsoft Windows Server 2008&#13;
+            windows2008-x64(22),       -- Microsoft Windows Server 2008 x64 Edition&#13;
+            windows2008-ia64(23),      -- Microsoft Windows Server 2008 for Itanium-based Systems&#13;
+            vmware-esx(24),            -- VMware ESX Classic&#13;
+            vmware-esxi(25),           -- VMware ESXi&#13;
+            windows2012(26),           -- Microsoft Windows 2012 Server&#13;
+            windows7(27),              -- Microsoft Windows 7&#13;
+            windows7-x64(28),          -- Microsoft Windows 7 64-bit&#13;
+            windows8(29),              -- Microsoft Windows 8&#13;
+            windows8-x64(30),          -- Microsoft Windows 8 64-bit&#13;
+            windows81(31),             -- Microsoft Windows 8.1&#13;
+            windows81-x64(32),         -- Microsoft Windows 8.1 64-bit&#13;
+            windowsxp(33),             -- Microsoft Windows XP&#13;
+            windowsxp-x64(34),         -- Microsoft Windows XP 64-Bit&#13;
+            windowsvista(35),          -- Microsoft Windows Vista&#13;
+            windowsvista-x64(36),      -- Microsoft Windows Vista 64-Bit&#13;
+            windows2008-r2(37),        -- Microsoft Windows Server 2008 R2&#13;
+            windows2012-r2(38),        -- Microsoft Windows Server 2012 R2&#13;
+            rhel(39),                  -- RedHat Enterprise Linux&#13;
+            rhel-64(40),               -- RedHat Enterprise Linux 64-Bit&#13;
+            solaris-64(41),            -- Solaris 64-Bit&#13;
+            sles(42),                  -- SUSE Linux Enterprise Server&#13;
+            sles-64(43),               -- SUSE Linux Enterprise Server 64-Bit&#13;
+            ubuntu(44),                -- Ubuntu&#13;
+            ubuntu-64(45),             -- Ubuntu 64-Bit&#13;
+            debian(46),                -- Debian&#13;
+            debian-64(47),             -- Debian 64-Bit&#13;
+            linux-64-bit(48),          -- Linux 64-Bit&#13;
+            other-64-bit(49),          -- Other 64-Bit&#13;
+            centos-32bit(50),          -- CentOS 32-bit&#13;
+            centos-64bit(51),          -- CentOS 64-bit&#13;
+            oracle-linux32(52),        -- Oracle Linux 32-bit&#13;
+            oracle-linux64(53),        -- Oracle Linux 64-bit&#13;
+            apple-osx(54)              -- Apple OS X</description>
+                    <inventory_link>OS_SHORT</inventory_link>
+                    <applications>
+                        <application>
+                            <name>Inventory</name>
+                        </application>
+                    </applications>
+                    <valuemap>
+                        <name>CPQHOST-MIB::cpqHoOsType</name>
+                    </valuemap>
+                </item>
+                <item>
+                    <name>System: OS Version</name>
+                    <type>SNMP_AGENT</type>
+                    <snmp_oid>1.3.6.1.4.1.232.11.2.2.2.0</snmp_oid>
+                    <key>system.host.osVersion[cpqHoVersion.0]</key>
+                    <delay>1d</delay>
+                    <history>2w</history>
+                    <trends>0</trends>
+                    <value_type>TEXT</value_type>
+                    <description>CPQHOST-MIB::cpqHoVersion&#13;
+The version of the host OS.</description>
+                    <applications>
+                        <application>
+                            <name>Inventory</name>
+                        </application>
+                    </applications>
+                </item>
+                <item>
+                    <name>System: Hardware Formfactor</name>
+                    <type>SNMP_AGENT</type>
+                    <snmp_oid>1.3.6.1.4.1.232.2.2.2.2.0</snmp_oid>
+                    <key>system.hw.formfactor[cpqSiFormFactor.0]</key>
+                    <delay>1d</delay>
+                    <history>2w</history>
+                    <trends>0d</trends>
+                    <description>CPQSINFO-MIB::cpqSiFormFactor&#13;
+unknown(1), portable(2), laptop(3), desktop(4), tower(5), mini-tower(6), rack-mount(7)</description>
+                    <inventory_link>TYPE</inventory_link>
+                    <applications>
+                        <application>
+                            <name>Inventory</name>
+                        </application>
+                    </applications>
+                    <valuemap>
+                        <name>CPQSINFO-MIB::cpqSiFormFactor</name>
+                    </valuemap>
+                </item>
+                <item>
+                    <name>System: Hardware Model Name</name>
+                    <type>SNMP_AGENT</type>
+                    <snmp_oid>1.3.6.1.4.1.232.2.2.4.2.0</snmp_oid>
+                    <key>system.hw.model</key>
+                    <delay>1d</delay>
+                    <history>2w</history>
+                    <trends>0</trends>
+                    <value_type>CHAR</value_type>
+                    <description>MIB: CPQSINFO-MIB&#13;
 The machine product name.The name of the machine used in this system.</description>
-               <inventory_link>MODEL</inventory_link>
-               <applications>
-                  <application>
-                     <name>Inventory</name>
-                  </application>
-               </applications>
-               <preprocessing>
-                  <step>
-                     <type>DISCARD_UNCHANGED_HEARTBEAT</type>
-                     <params>1d</params>
-                  </step>
-               </preprocessing>
-            </item>
-            <item>
-               <name>Hardware serial number</name>
-               <type>SNMPV2</type>
-               <snmp_community>{$SNMP_COMMUNITY}</snmp_community>
-               <snmp_oid>1.3.6.1.4.1.232.2.2.2.1.0</snmp_oid>
-               <key>system.hw.serialnumber</key>
-               <delay>1h</delay>
-               <history>2w</history>
-               <trends>0</trends>
-               <value_type>CHAR</value_type>
-               <description>MIB: CPQSINFO-MIB&#13;
+                    <inventory_link>MODEL</inventory_link>
+                    <applications>
+                        <application>
+                            <name>Inventory</name>
+                        </application>
+                    </applications>
+                </item>
+                <item>
+                    <name>System: Hardware Product ID</name>
+                    <type>SNMP_AGENT</type>
+                    <snmp_oid>1.3.6.1.4.1.232.2.2.2.6.0</snmp_oid>
+                    <key>system.hw.productId[cpqSiSysProductId.0]</key>
+                    <delay>1d</delay>
+                    <history>2w</history>
+                    <trends>0</trends>
+                    <value_type>TEXT</value_type>
+                    <description>CPQSINFO-MIB::cpqSiSysProductId&#13;
+The product id string of the system unit. The string will be empty if the system does not report the product id.</description>
+                    <inventory_link>CHASSIS</inventory_link>
+                    <applications>
+                        <application>
+                            <name>Inventory</name>
+                        </application>
+                    </applications>
+                </item>
+                <item>
+                    <name>System: Hardware Serial Number</name>
+                    <type>SNMP_AGENT</type>
+                    <snmp_oid>1.3.6.1.4.1.232.2.2.2.1.0</snmp_oid>
+                    <key>system.hw.serialnumber</key>
+                    <delay>1d</delay>
+                    <history>2w</history>
+                    <trends>0</trends>
+                    <value_type>CHAR</value_type>
+                    <description>MIB: CPQSINFO-MIB&#13;
 The serial number of the physical system unit. The string will be empty if the system does not report the serial number function.</description>
-               <inventory_link>SERIALNO_A</inventory_link>
-               <applications>
-                  <application>
-                     <name>Inventory</name>
-                  </application>
-               </applications>
-               <preprocessing>
-                  <step>
-                     <type>DISCARD_UNCHANGED_HEARTBEAT</type>
-                     <params>1d</params>
-                  </step>
-               </preprocessing>
-               <triggers>
-                  <trigger>
-                     <expression>{diff()}=1 and {strlen()}&gt;0</expression>
-                     <name>Device has been replaced (new serial number received)</name>
-                     <priority>INFO</priority>
-                     <description>Device serial number has changed. Ack to close</description>
-                     <manual_close>YES</manual_close>
-                  </trigger>
-               </triggers>
-            </item>
-            <item>
-               <name>Overall system health status</name>
-               <type>SNMPV2</type>
-               <snmp_community>{$SNMP_COMMUNITY}</snmp_community>
-               <snmp_oid>1.3.6.1.4.1.232.6.1.3.0</snmp_oid>
-               <key>system.status[cpqHeMibCondition.0]</key>
-               <delay>30s</delay>
-               <history>2w</history>
-               <trends>0d</trends>
-               <description>MIB: CPQHLTH-MIB&#13;
-The overall condition. This object represents the overall status of the server information represented by this MIB.</description>
-               <applications>
-                  <application>
-                     <name>Status</name>
-                  </application>
-               </applications>
-               <valuemap>
-                  <name>CPQSINFO-MIB::status</name>
-               </valuemap>
-               <triggers>
-                  <trigger>
-                     <expression>{count(#1,{$HEALTH_CRIT_STATUS},eq)}=1</expression>
-                     <name>System status is in critical state</name>
-                     <opdata>Current state: {ITEM.LASTVALUE1}</opdata>
-                     <priority>HIGH</priority>
-                     <description>Please check the device for errors</description>
-                  </trigger>
-                  <trigger>
-                     <expression>{count(#1,{$HEALTH_WARN_STATUS},eq)}=1</expression>
-                     <name>System status is in warning state</name>
-                     <opdata>Current state: {ITEM.LASTVALUE1}</opdata>
-                     <priority>WARNING</priority>
-                     <description>Please check the device for warnings</description>
-                     <dependencies>
-                        <dependency>
-                           <name>System status is in critical state</name>
-                           <expression>{Template Server HP iLO SNMPv2:system.status[cpqHeMibCondition.0].count(#1,{$HEALTH_CRIT_STATUS},eq)}=1</expression>
-                        </dependency>
-                     </dependencies>
-                  </trigger>
-               </triggers>
-            </item>
-         </items>
-         <discovery_rules>
-            <discovery_rule>
-               <name>Array Controller Cache Discovery</name>
-               <type>SNMPV2</type>
-               <snmp_community>{$SNMP_COMMUNITY}</snmp_community>
-               <snmp_oid>discovery[{#CACHE_STATUS},1.3.6.1.4.1.232.3.2.2.2.1.2,{#CACHE_CNTRL_INDEX},1.3.6.1.4.1.232.3.2.2.2.1.1]</snmp_oid>
-               <key>array.cache.discovery</key>
-               <delay>1h</delay>
-               <description>Scanning table of Array controllers: CPQIDA-MIB::cpqDaAccelTable</description>
-               <item_prototypes>
-                  <item_prototype>
-                     <name>#{#CACHE_CNTRL_INDEX}: Disk array cache controller battery status</name>
-                     <type>SNMPV2</type>
-                     <snmp_community>{$SNMP_COMMUNITY}</snmp_community>
-                     <snmp_oid>1.3.6.1.4.1.232.3.2.2.2.1.6.{#SNMPINDEX}</snmp_oid>
-                     <key>system.hw.diskarray.cache.battery.status[cpqDaAccelBattery.{#SNMPINDEX}]</key>
-                     <history>1w</history>
-                     <trends>0d</trends>
-                     <description>MIB: CPQIDA-MIB&#13;
+                    <inventory_link>SERIALNO_A</inventory_link>
+                    <applications>
+                        <application>
+                            <name>Inventory</name>
+                        </application>
+                    </applications>
+                    <triggers>
+                        <trigger>
+                            <expression>{diff()}=1 and {strlen()}&gt;0</expression>
+                            <recovery_mode>NONE</recovery_mode>
+                            <name>Device has been replaced (new serial number received)</name>
+                            <priority>INFO</priority>
+                            <description>Last value: {ITEM.LASTVALUE1}.&#13;
+Device serial number has changed. Ack to close</description>
+                            <manual_close>YES</manual_close>
+                        </trigger>
+                    </triggers>
+                </item>
+                <item>
+                    <name>System: Memory Current Type</name>
+                    <type>SNMP_AGENT</type>
+                    <snmp_oid>1.3.6.1.4.1.232.6.2.14.1.0</snmp_oid>
+                    <key>system.mem.type.active[cpqHeResilientMemTypeActive.0]</key>
+                    <delay>1d</delay>
+                    <trends>0</trends>
+                    <description>CPQHLTH-MIB::cpqHeResilientMemTypeActive&#13;
+&#13;
+This value specifies the type of Advanced Memory Protection fault&#13;
+tolerance currently active on the system.&#13;
+The following connection states are supported:&#13;
+other(1)&#13;
+  The Advanced Memory Protection fault tolerance cannot be&#13;
+  determined by the Management Agent.  You may need to upgrade&#13;
+  your software.&#13;
+none(2)&#13;
+  This system is not configured for Advanced Memory Protection&#13;
+  fault tolerance or Advanced Memory Protection is not available&#13;
+  on this system.&#13;
+onLineSpare(3)&#13;
+  This system is configured for Online Spare Advanced Memory&#13;
+  Protection.&#13;
+mirrored(4)&#13;
+  This system is configured for Mirrored Advanced Memory&#13;
+  Protection.&#13;
+advancedECC(5)&#13;
+  This system is configured for the Advanced ECC type of&#13;
+  Advanced Memory Protection.</description>
+                    <applications>
+                        <application>
+                            <name>Inventory</name>
+                        </application>
+                        <application>
+                            <name>Memory</name>
+                        </application>
+                    </applications>
+                    <valuemap>
+                        <name>CPQHLTH-MIB::cpqHeResilientMemTypeActive</name>
+                    </valuemap>
+                </item>
+                <item>
+                    <name>System: Memory Current Condition</name>
+                    <type>SNMP_AGENT</type>
+                    <snmp_oid>1.3.6.1.4.1.232.6.2.14.4.0</snmp_oid>
+                    <key>system.mem.type.condition[cpqHeResilientMemCondition.0]</key>
+                    <description>CPQHLTH-MIB::cpqHeResilientMemCondition&#13;
+&#13;
+This value specifies the current condition of the Advanced&#13;
+Memory Protection subsystem.&#13;
+The following states are supported:&#13;
+other(1)&#13;
+  The system does not support fault tolerant memory or the&#13;
+  state cannot be determined by the Management Agent.&#13;
+ok(2)&#13;
+  This system is operating normally.&#13;
+degraded(3)&#13;
+  The system is running in a degraded state because the&#13;
+  Advanced Memory Protection subsystem has been engaged.</description>
+                    <applications>
+                        <application>
+                            <name>Inventory</name>
+                        </application>
+                        <application>
+                            <name>Memory</name>
+                        </application>
+                    </applications>
+                    <valuemap>
+                        <name>CPQHLTH-MIB::cpqHeResilientMemCondition</name>
+                    </valuemap>
+                    <triggers>
+                        <trigger>
+                            <expression>{last()}&lt;&gt;2</expression>
+                            <recovery_mode>RECOVERY_EXPRESSION</recovery_mode>
+                            <recovery_expression>{last()}=2</recovery_expression>
+                            <name>Memory resiliency lost on {#HOST.NAME}</name>
+                            <priority>HIGH</priority>
+                        </trigger>
+                    </triggers>
+                </item>
+                <item>
+                    <name>System: Memory Current Size</name>
+                    <type>SNMP_AGENT</type>
+                    <snmp_oid>1.3.6.1.4.1.232.6.2.14.8.0</snmp_oid>
+                    <key>system.mem.type.size[cpqHeResilientMemTotalMemSize.0]</key>
+                    <delay>1d</delay>
+                    <history>2w</history>
+                    <trends>0d</trends>
+                    <units>B</units>
+                    <description>CPQHLTH-MIB::cpqHeResilientMemTotalMemSize&#13;
+This value specifies the total size of memory including memory seen by the Operating System and the memory used for spare, mirrored, or RAID configurations in MB (1 MB = 1048576 bytes). If this system does not support Advanced Memory Protection or this value cannot be determined, then a value of 0 will be returned.</description>
+                    <applications>
+                        <application>
+                            <name>Inventory</name>
+                        </application>
+                        <application>
+                            <name>Memory</name>
+                        </application>
+                    </applications>
+                    <preprocessing>
+                        <step>
+                            <type>MULTIPLIER</type>
+                            <params>1048576</params>
+                        </step>
+                    </preprocessing>
+                </item>
+                <item>
+                    <name>System: Memory Current Status</name>
+                    <type>SNMP_AGENT</type>
+                    <snmp_oid>1.3.6.1.4.1.232.6.2.14.3.0</snmp_oid>
+                    <key>system.mem.type.status[cpqHeResilientMemStatus.0]</key>
+                    <delay>5m</delay>
+                    <description>CPQHLTH-MIB::cpqHeResilientMemStatus&#13;
+&#13;
+This value specifies the current state of the Advanced&#13;
+Memory Protection subsystem.&#13;
+The following states are supported:&#13;
+other(1)&#13;
+  The system does not support Advanced Memory Protection or the&#13;
+  status cannot be determined by the Management Agent.&#13;
+notProtected(2)&#13;
+  This system supports Advanced Memory Protection but the&#13;
+  feature is disabled.&#13;
+protected(3)&#13;
+  The system is protected by Advanced Memory Protection.&#13;
+degraded(4)&#13;
+  The system was protected, but the Advanced Memory&#13;
+  Protection feature has been engaged.&#13;
+dimmEcc(5)&#13;
+  The system is protected via DIMM ECC only.&#13;
+mirrorNoFaults(6)&#13;
+  The system is protected by Advanced Memory Protection in the&#13;
+  mirrored mode.  No DIMM faults have been detected.&#13;
+mirrorWithFaults(7)&#13;
+  The system is protected by Advanced Memory Protection in the&#13;
+  mirrored mode.  One or more DIMM faults have been detected.&#13;
+hotSpareNoFaults(8)&#13;
+  The system is protected by Advanced Memory Protection in the&#13;
+  hot spare mode.  No DIMM faults have been detected.&#13;
+hotSpareWithFaults(9)&#13;
+  The system is protected by Advanced Memory Protection in the&#13;
+  hot spare mode.  One or more DIMM faults have been detected.&#13;
+xorNoFaults(10)&#13;
+  The system is protected by Advanced Memory Protection in the&#13;
+  XOR memory mode.  No DIMM faults have been detected.&#13;
+xorWithFaults(11)&#13;
+  The system is protected by Advanced Memory Protection in the&#13;
+  XOR memory mode.  One or more DIMM faults have been detected.&#13;
+advancedEcc(12)&#13;
+  The system is protected by Advanced Memory Protection in the&#13;
+  Advanced ECC mode.&#13;
+  &#13;
+advancedEccWithFaults(13)&#13;
+  The system is protected by Advanced Memory Protection in the&#13;
+  Advanced ECC mode. One or more DIMM faults have been detected.&#13;
+lockStep(14)&#13;
+  The system is protected by Advanced Memory Protection in the&#13;
+  Lock Step mode.&#13;
+  &#13;
+localStepWithFaults(15)&#13;
+  The system is protected by Advanced Memory Protection in the&#13;
+  Lock Step mode. One or more DIMM faults have been detected.</description>
+                    <applications>
+                        <application>
+                            <name>Inventory</name>
+                        </application>
+                        <application>
+                            <name>Memory</name>
+                        </application>
+                    </applications>
+                    <valuemap>
+                        <name>CPQHLTH-MIB::cpqHeResilientMemStatus</name>
+                    </valuemap>
+                </item>
+                <item>
+                    <name>System: Power Meter Reading</name>
+                    <type>SNMP_AGENT</type>
+                    <snmp_oid>1.3.6.1.4.1.232.6.2.15.3.0</snmp_oid>
+                    <key>system.psu.meter.reading[cpqHePowerMeterCurrReading.0]</key>
+                    <delay>5m</delay>
+                    <units>W</units>
+                    <description>CPQHLTH::cpqHePowerMeterCurrReading&#13;
+&#13;
+This is the current Power Meter reading in Watts. This value shows the most recent power reading if available. On systems without Power Meter support, this value will be -1</description>
+                    <applications>
+                        <application>
+                            <name>Power Supply</name>
+                        </application>
+                    </applications>
+                </item>
+                <item>
+                    <name>System: Power Meter Status</name>
+                    <type>SNMP_AGENT</type>
+                    <snmp_oid>1.3.6.1.4.1.232.6.2.15.2.0</snmp_oid>
+                    <key>system.psu.meter.status[cpqHePowerMeterStatus.0]</key>
+                    <delay>1d</delay>
+                    <history>2w</history>
+                    <trends>0d</trends>
+                    <description>CPQHLTH::cpqHePowerMeterStatus&#13;
+&#13;
+This value specifies whether Power Meter reading is supported by this Server . The following values are supported: other(1) Could not read the Power Meter status. present(2) The Power Meter data is available. absent(3) The Power Meter data is not available at this time.</description>
+                    <applications>
+                        <application>
+                            <name>Power Supply</name>
+                        </application>
+                    </applications>
+                    <valuemap>
+                        <name>CPQHLTH-MIB::cpqHePowerMeterStatus</name>
+                    </valuemap>
+                </item>
+                <item>
+                    <name>System: Power Meter Support</name>
+                    <type>SNMP_AGENT</type>
+                    <snmp_oid>1.3.6.1.4.1.232.6.2.15.1.0</snmp_oid>
+                    <key>system.psu.meter.support[cpqHePowerMeterSupport.0]</key>
+                    <delay>1d</delay>
+                    <history>2w</history>
+                    <trends>0d</trends>
+                    <description>CPQHLTH-MIB::cpqHePowerMeterSupport&#13;
+&#13;
+This value specifies whether Power Meter is supported by this Server . The following values are supported: other(1) Could not read the Power Meter status. supported(2) This system support Power Meter. unsupported(3) This system does not support Power Meter.</description>
+                    <applications>
+                        <application>
+                            <name>Power Supply</name>
+                        </application>
+                    </applications>
+                    <valuemap>
+                        <name>CPQHLTH-MIB::cpqHePowerMeterSupport</name>
+                    </valuemap>
+                </item>
+                <item>
+                    <name>System: Overall Health Status</name>
+                    <type>SNMP_AGENT</type>
+                    <snmp_oid>1.3.6.1.4.1.232.2.1.3.0</snmp_oid>
+                    <key>system.status[cpqSiMibCondition.0]</key>
+                    <history>2w</history>
+                    <trends>0d</trends>
+                    <description>MIB: CPQSINFO-MIB&#13;
+&#13;
+The overall condition. This object represents the overall status of the server information represented by this MIB.&#13;
+&#13;
+other(1), ok(2), degraded(3), failed(4)</description>
+                    <applications>
+                        <application>
+                            <name>General</name>
+                        </application>
+                        <application>
+                            <name>Status</name>
+                        </application>
+                    </applications>
+                    <valuemap>
+                        <name>CPQSINFO-MIB::status</name>
+                    </valuemap>
+                    <triggers>
+                        <trigger>
+                            <expression>{last()}&lt;&gt;3&#13;
+and &#13;
+{last()}=4</expression>
+                            <recovery_mode>RECOVERY_EXPRESSION</recovery_mode>
+                            <recovery_expression>{last()}&lt;&gt;3&#13;
+or&#13;
+{last()}&lt;&gt;4</recovery_expression>
+                            <name>System status is in critical state</name>
+                            <priority>HIGH</priority>
+                            <description>Last value: {ITEM.LASTVALUE1}.&#13;
+Please check the device for errors</description>
+                        </trigger>
+                        <trigger>
+                            <expression>{last()}=3 &#13;
+and &#13;
+{last()}&lt;&gt;4</expression>
+                            <recovery_mode>RECOVERY_EXPRESSION</recovery_mode>
+                            <recovery_expression>{last()}&lt;&gt;3&#13;
+or&#13;
+{last()}&lt;&gt;4</recovery_expression>
+                            <name>System status is in warning state</name>
+                            <priority>WARNING</priority>
+                            <description>Last value: {ITEM.LASTVALUE1}.&#13;
+Please check the device for warnings</description>
+                        </trigger>
+                    </triggers>
+                </item>
+            </items>
+            <discovery_rules>
+                <discovery_rule>
+                    <name>Array Controller Cache Discovery</name>
+                    <type>SNMP_AGENT</type>
+                    <snmp_oid>discovery[{#CACHE_STATUS},1.3.6.1.4.1.232.3.2.2.2.1.2,{#CACHE_CNTRL_INDEX},1.3.6.1.4.1.232.3.2.2.2.1.1]</snmp_oid>
+                    <key>array.cache.discovery</key>
+                    <delay>1h</delay>
+                    <description>Scanning table of Array controllers: CPQIDA-MIB::cpqDaAccelTable</description>
+                    <item_prototypes>
+                        <item_prototype>
+                            <name>Slot {#CACHE_CNTRL_INDEX}: Controller cache battery status</name>
+                            <type>SNMP_AGENT</type>
+                            <snmp_oid>1.3.6.1.4.1.232.3.2.2.2.1.6.{#SNMPINDEX}</snmp_oid>
+                            <key>system.hw.diskarray.cache.battery.status[cpqDaAccelBattery.{#SNMPINDEX}]</key>
+                            <delay>5m</delay>
+                            <history>1w</history>
+                            <trends>0d</trends>
+                            <description>MIB: CPQIDA-MIB&#13;
 Cache Module Board Backup Power Status. This monitors the status of each backup power source on the board.&#13;
 The backup power source can only recharge when the system has power applied. The type of backup power source used is indicated by cpqDaAccelBackupPowerSource.&#13;
 The following values are valid:&#13;
@@ -222,321 +630,720 @@ Your Cache  Module board should be serviced as soon as possible.&#13;
 NotPresent (6)  A backup power source is not present on the cache module board. Some controllers do not have backup power sources.&#13;
 &#13;
 Capacitor Failed (7)  The flash backed cache module capacitor is below the sufficient voltage level and has not recharged in 10 minutes.  Your Cache Module board needs to be serviced.</description>
-                     <applications>
-                        <application>
-                           <name>Disk arrays</name>
-                        </application>
-                     </applications>
-                     <valuemap>
-                        <name>CPQIDA-MIB::cpqDaAccelBattery</name>
-                     </valuemap>
-                     <trigger_prototypes>
-                        <trigger_prototype>
-                           <expression>{count(#1,{$DISK_ARRAY_CACHE_BATTERY_CRIT_STATUS:"failed"},eq)}=1 or {count(#1,{$DISK_ARRAY_CACHE_BATTERY_CRIT_STATUS:"capacitorFailed"},eq)}=1</expression>
-                           <name>#{#CACHE_CNTRL_INDEX}: Disk array cache controller battery is in critical state!</name>
-                           <opdata>Current state: {ITEM.LASTVALUE1}</opdata>
-                           <priority>AVERAGE</priority>
-                           <description>Please check the device for faults</description>
-                        </trigger_prototype>
-                        <trigger_prototype>
-                           <expression>{count(#1,{$DISK_ARRAY_CACHE_BATTERY_WARN_STATUS:"degraded"},eq)}=1 or {count(#1,{$DISK_ARRAY_CACHE_BATTERY_WARN_STATUS:"notPresent"},eq)}=1</expression>
-                           <name>#{#CACHE_CNTRL_INDEX}: Disk array cache controller battery is in warning state</name>
-                           <opdata>Current state: {ITEM.LASTVALUE1}</opdata>
-                           <priority>WARNING</priority>
-                           <description>Please check the device for faults</description>
-                           <dependencies>
-                              <dependency>
-                                 <name>#{#CACHE_CNTRL_INDEX}: Disk array cache controller battery is in critical state!</name>
-                                 <expression>{Template Server HP iLO SNMPv2:system.hw.diskarray.cache.battery.status[cpqDaAccelBattery.{#SNMPINDEX}].count(#1,{$DISK_ARRAY_CACHE_BATTERY_CRIT_STATUS:"failed"},eq)}=1 or {Template Server HP iLO SNMPv2:system.hw.diskarray.cache.battery.status[cpqDaAccelBattery.{#SNMPINDEX}].count(#1,{$DISK_ARRAY_CACHE_BATTERY_CRIT_STATUS:"capacitorFailed"},eq)}=1</expression>
-                              </dependency>
-                           </dependencies>
-                        </trigger_prototype>
-                     </trigger_prototypes>
-                  </item_prototype>
-                  <item_prototype>
-                     <name>#{#CACHE_CNTRL_INDEX}: Disk array cache controller status</name>
-                     <type>SNMPV2</type>
-                     <snmp_community>{$SNMP_COMMUNITY}</snmp_community>
-                     <snmp_oid>1.3.6.1.4.1.232.3.2.2.2.1.2.{#SNMPINDEX}</snmp_oid>
-                     <key>system.hw.diskarray.cache.status[cpqDaAccelStatus.{#SNMPINDEX}]</key>
-                     <history>1w</history>
-                     <trends>0d</trends>
-                     <description>MIB: CPQIDA-MIB&#13;
+                            <applications>
+                                <application>
+                                    <name>Disk Arrays</name>
+                                </application>
+                            </applications>
+                            <valuemap>
+                                <name>CPQIDA-MIB::cpqDaAccelBattery</name>
+                            </valuemap>
+                            <trigger_prototypes>
+                                <trigger_prototype>
+                                    <expression>{last()}=4&#13;
+or&#13;
+{last()}=7</expression>
+                                    <recovery_mode>RECOVERY_EXPRESSION</recovery_mode>
+                                    <recovery_expression>{last()}&lt;&gt;4&#13;
+or&#13;
+{last()}&lt;&gt;7</recovery_expression>
+                                    <name>Slot {#CACHE_CNTRL_INDEX}: Disk array cache controller battery is in critical state!</name>
+                                    <priority>HIGH</priority>
+                                    <description>Last value: {ITEM.LASTVALUE1}.&#13;
+Please check the device for faults</description>
+                                </trigger_prototype>
+                                <trigger_prototype>
+                                    <expression>{last()}=5</expression>
+                                    <recovery_mode>RECOVERY_EXPRESSION</recovery_mode>
+                                    <recovery_expression>{last()}&lt;&gt;5</recovery_expression>
+                                    <name>Slot {#CACHE_CNTRL_INDEX}: Disk array cache controller battery is in warning state</name>
+                                    <priority>WARNING</priority>
+                                    <description>Last value: {ITEM.LASTVALUE1}.&#13;
+Please check the device for faults</description>
+                                </trigger_prototype>
+                            </trigger_prototypes>
+                        </item_prototype>
+                        <item_prototype>
+                            <name>Slot {#CACHE_CNTRL_INDEX}: Controller cache status code</name>
+                            <type>SNMP_AGENT</type>
+                            <snmp_oid>1.3.6.1.4.1.232.3.2.2.2.1.5.{#SNMPINDEX}</snmp_oid>
+                            <key>system.hw.diskarray.cache.code[cpqDaAccelErrCode.{#SNMPINDEX}]</key>
+                            <delay>5m</delay>
+                            <history>1w</history>
+                            <trends>0d</trends>
+                            <description>CPQIDA-MIB::cpqDaAccelErrCode&#13;
+&#13;
+Cache Module Board Error Code. Use this to determine the status of the write cache operations. The status can be: Other (1) Indicates that the instrument agent does not recognize the error code. You may need to update your software. Invalid (2) Indicates that write cache operations are currently configured and enabled for at least one logical drive. No write cache errors have occurred. Bad Configuration (3) Indicates that write cache operations are temporarily disabled. The Cache Module board was configured for a different controller. This error could be caused if boards were switched from one system to another. Rerun the configuration utility and ensure that the board has been properly configured for this system. Note: If data from another system was stored on the board, running configuration utility will cause the data to be lost. Low Battery Power (4) Indicates that write cache operations are temporarily disabled due to insufficient battery power. Please view the Battery Status object instance for more information. Disable Command Issued (5) Indicates that write cache operations are temporarily disabled. The device driver issues this command when the server is taken down. This condition should not exist when the system regains power. No Resources Available (6) Indicates that write cache operations are temporarily disabled. The controller does not have sufficient resources to perform write cache operations. For example, when a replaced drive is being rebuilt, there will not be sufficient resources. Once the operation that requires the resources has completed, this condition will clear and write cache operations will resume. Board Not Connected (7) Indicates that write cache operations are temporarily disabled. The Cache Module board has been configured but is not currently attached to the controller. Check the alignment of the board and connections. Bad Mirror Data (8) Indicates that write cache operations have been permanently disabled. The Cache Module board stores mirrored copies of all data. If data exists on the board when the system is first powered up, the board performs a data compare test between the mirrored copies. If the data does not match, an error has occurred. Data may have been lost. Your board may need servicing. Read Failure (9) Indicates that write cache operations have been permanently disabled. The Cache Module board stores mirror copies of all data. While reading the data from the board, memory parity errors have occurred. Both copies were corrupted and cannot be retrieved. Data has been lost, and you should service the board. Write Failure (10) Indicates that write cache operations have been permanently disabled. This error occurs when an unsuccessful attempt was made to write data to the Cache Module board. Data could not be written to write cache memory in duplicate due to the detection of parity errors. This error does not indicate data loss. You should service the Cache Module board. Config Command (11) Indicates that write cache operations have been permanently disabled. The configuration of the logical drives has changed. You need to reconfigure the Cache Module board. Expand in Progress (12) Indicates that cache operations are temporarily disabled due to an expand of a logical drive. When the expand operation completes, the cache module will be enabled. Snapshot In Progress (13) Indicates that cache operations are temporarily disabled due to a snapshot operation that is queued up or in progress. When the snapshot operation completes, the cache module will be enabled. Redundant Low Battery (14) Indicates that cache operations are temporarily disabled. The redundant controller has insufficient cache battery power. Redundant Size Mismatch (15) Indicates that cache operations are temporarily disabled. The cache sizes on the redundant controllers do not match. Redundant Cache Failure (16) Indicates that cache operations are temporarily disabled. The cache on the redundant controller has failed. Excessive ECC Errors (17) Indicates that write cache operations have been permanently disabled. The number of cache lines experiencing excessive ECC errors has reached a preset limit. RAID ADG Enabler Module Missing (18) Indicates that write cache operations have been temperarily disabled. A RAID ADG logical drive is configured but the RAID ADG Enabler Module is broken or missing. Power On Self Test (Post) ECC Errors (19) Indicates that write cache operations have been permanently disabled. The cache has been disabled due to a large number of ECC errors detected while testing the cache during Power On Self Test (Post). Backup Power Source Hot Removed (20) Indicates that write cache operations have been permanently disabled. The cache has been disabled because a backup power source has been hot removed. Flash Backed Cache Module Capacitor Charge Low (21) Indicates that write cache operations are temporarily disabled due to insufficient capacitor power. Not Enough Batteries (22) Indicates that write cache operations have been permanently disabled. The cache has been disabled because there are not enough batteries attached to the controller to ensure write cache will be held without power for the advertised length of time. Cache Module Not Supported By Firmware (23) Indicates that write cache operations have been permanently disabled. The cache has been disabled because the current cache module is not supported by the currently running firmware. Battery Not Supported (24) Indicates that write cache operations have been permanently disabled. The cache has been disabled because one or more attached batteries are not supported by the currently running firmware. No Capacitor Attached (25) Indicates that write cache operations have been permanently disabled. The cache has been disabled because there are no capacitors attached to the flash backed cache module. Flash Backed Cache Module Backup Failed (26) Indicates that write cache operations have been permanently disabled. The cache has been disabled because the flash backed cache module backup operation has failed. Flash Backed Cache Module Restore Failed (27) Indicates that write cache operations have been permanently disabled. The cache has been disabled because the flash backed cache module restore operation has failed. Flash Backed Cache Module Hardware Failure (28) Indicates that write cache operations have been permanently disabled. The cache has been disabled because the flash backed cache module has encountered a hardware failure. Capacitor Failed To Charge (29) Indicates that write cache operations have been permanently disabled. The cache has been disabled because the flash backed cache module capacitor has failed to charge. Flash Backed Cache Module Memory Being Erased (30) Indicates that write cache operations have been temporarily disabled. The cache has been disabled because the flash backed cache module is erasing its flash memory. Incompatible Cache Module (31) Indicates that write cache operations have been permanently disabled. The cache has been disabled because an incompatible cache module is being used. Flash Backed Cache Module Charger Circuit Failure (32) Indicates that write cache operations have been permanently disabled. The cache has been disabled because the charger circuit on the flash backed cache module has failed.</description>
+                            <applications>
+                                <application>
+                                    <name>Disk Arrays</name>
+                                </application>
+                            </applications>
+                            <valuemap>
+                                <name>CPQIDA-MIB::cpqDaAccelStatus</name>
+                            </valuemap>
+                        </item_prototype>
+                        <item_prototype>
+                            <name>Slot {#CACHE_CNTRL_INDEX}: Controller cache serial</name>
+                            <type>SNMP_AGENT</type>
+                            <snmp_oid>1.3.6.1.4.1.232.3.2.2.2.1.2.{#SNMPINDEX}</snmp_oid>
+                            <key>system.hw.diskarray.cache.serial[cpqDaAccelSerialNumber.{#SNMPINDEX}]</key>
+                            <delay>1d</delay>
+                            <trends>0</trends>
+                            <value_type>TEXT</value_type>
+                            <description>CPQIDA-MIB::cpqDaAccelSerialNumber&#13;
+&#13;
+Cache Module Serial Number. The serial number of the Cache Module. This field will be a null (size 0) string if the cache module does not support serial number.</description>
+                            <applications>
+                                <application>
+                                    <name>Disk Arrays</name>
+                                </application>
+                                <application>
+                                    <name>Inventory</name>
+                                </application>
+                            </applications>
+                        </item_prototype>
+                        <item_prototype>
+                            <name>Slot {#CACHE_CNTRL_INDEX}: Controller cache status</name>
+                            <type>SNMP_AGENT</type>
+                            <snmp_oid>1.3.6.1.4.1.232.3.2.2.2.1.2.{#SNMPINDEX}</snmp_oid>
+                            <key>system.hw.diskarray.cache.status[cpqDaAccelStatus.{#SNMPINDEX}]</key>
+                            <delay>5m</delay>
+                            <history>1w</history>
+                            <trends>0d</trends>
+                            <description>MIB: CPQIDA-MIB&#13;
 Cache Module/Operations Status. This describes the status of the cache module and/or cache operations.&#13;
 Note that for some controller models, a cache module board that physically attaches to the controller or chipset may not be an available option.</description>
-                     <applications>
-                        <application>
-                           <name>Disk arrays</name>
-                        </application>
-                     </applications>
-                     <valuemap>
-                        <name>CPQIDA-MIB::cpqDaAccelStatus</name>
-                     </valuemap>
-                     <trigger_prototypes>
-                        <trigger_prototype>
-                           <expression>{count(#1,{$DISK_ARRAY_CACHE_CRIT_STATUS:"cacheModCriticalFailure"},eq)}=1</expression>
-                           <name>#{#CACHE_CNTRL_INDEX}: Disk array cache controller is in critical state!</name>
-                           <opdata>Current state: {ITEM.LASTVALUE1}</opdata>
-                           <priority>AVERAGE</priority>
-                           <description>Please check the device for faults</description>
-                        </trigger_prototype>
-                        <trigger_prototype>
-                           <expression>{count(#1,{$DISK_ARRAY_CACHE_WARN_STATUS:"invalid"},eq)}=1 or {count(#1,{$DISK_ARRAY_CACHE_WARN_STATUS:"cacheModDegradedFailsafeSpeed"},eq)}=1 or {count(#1,{$DISK_ARRAY_CACHE_WARN_STATUS:"cacheReadCacheNotMapped"},eq)}=1 or {count(#1,{$DISK_ARRAY_CACHE_WARN_STATUS:"cacheModFlashMemNotAttached"},eq)}=1</expression>
-                           <name>#{#CACHE_CNTRL_INDEX}: Disk array cache controller is in warning state</name>
-                           <opdata>Current state: {ITEM.LASTVALUE1}</opdata>
-                           <priority>WARNING</priority>
-                           <description>Please check the device for faults</description>
-                           <dependencies>
-                              <dependency>
-                                 <name>#{#CACHE_CNTRL_INDEX}: Disk array cache controller is in critical state!</name>
-                                 <expression>{Template Server HP iLO SNMPv2:system.hw.diskarray.cache.status[cpqDaAccelStatus.{#SNMPINDEX}].count(#1,{$DISK_ARRAY_CACHE_CRIT_STATUS:"cacheModCriticalFailure"},eq)}=1</expression>
-                              </dependency>
-                           </dependencies>
-                        </trigger_prototype>
-                        <trigger_prototype>
-                           <expression>{count(#1,{$DISK_ARRAY_CACHE_OK_STATUS:"enabled"},ne)}=1</expression>
-                           <name>#{#CACHE_CNTRL_INDEX}: Disk array cache controller is not in optimal state</name>
-                           <opdata>Current state: {ITEM.LASTVALUE1}</opdata>
-                           <priority>WARNING</priority>
-                           <description>Please check the device for faults</description>
-                           <dependencies>
-                              <dependency>
-                                 <name>#{#CACHE_CNTRL_INDEX}: Disk array cache controller is in critical state!</name>
-                                 <expression>{Template Server HP iLO SNMPv2:system.hw.diskarray.cache.status[cpqDaAccelStatus.{#SNMPINDEX}].count(#1,{$DISK_ARRAY_CACHE_CRIT_STATUS:"cacheModCriticalFailure"},eq)}=1</expression>
-                              </dependency>
-                              <dependency>
-                                 <name>#{#CACHE_CNTRL_INDEX}: Disk array cache controller is in warning state</name>
-                                 <expression>{Template Server HP iLO SNMPv2:system.hw.diskarray.cache.status[cpqDaAccelStatus.{#SNMPINDEX}].count(#1,{$DISK_ARRAY_CACHE_WARN_STATUS:"invalid"},eq)}=1 or {Template Server HP iLO SNMPv2:system.hw.diskarray.cache.status[cpqDaAccelStatus.{#SNMPINDEX}].count(#1,{$DISK_ARRAY_CACHE_WARN_STATUS:"cacheModDegradedFailsafeSpeed"},eq)}=1 or {Template Server HP iLO SNMPv2:system.hw.diskarray.cache.status[cpqDaAccelStatus.{#SNMPINDEX}].count(#1,{$DISK_ARRAY_CACHE_WARN_STATUS:"cacheReadCacheNotMapped"},eq)}=1 or {Template Server HP iLO SNMPv2:system.hw.diskarray.cache.status[cpqDaAccelStatus.{#SNMPINDEX}].count(#1,{$DISK_ARRAY_CACHE_WARN_STATUS:"cacheModFlashMemNotAttached"},eq)}=1</expression>
-                              </dependency>
-                           </dependencies>
-                        </trigger_prototype>
-                     </trigger_prototypes>
-                  </item_prototype>
-               </item_prototypes>
-            </discovery_rule>
-            <discovery_rule>
-               <name>Array Controller Discovery</name>
-               <type>SNMPV2</type>
-               <snmp_community>{$SNMP_COMMUNITY}</snmp_community>
-               <snmp_oid>discovery[{#SNMPVALUE},1.3.6.1.4.1.232.3.2.2.1.1.1,{#CNTLR_SLOT},1.3.6.1.4.1.232.3.2.2.1.1.5,{#CNTLR_LOCATION},1.3.6.1.4.1.232.3.2.2.1.1.20]</snmp_oid>
-               <key>array.discovery</key>
-               <delay>1h</delay>
-               <description>Scanning table of Array controllers: CPQIDA-MIB::cpqDaCntlrTable</description>
-               <item_prototypes>
-                  <item_prototype>
-                     <name>{#CNTLR_LOCATION}: Disk array controller model</name>
-                     <type>SNMPV2</type>
-                     <snmp_community>{$SNMP_COMMUNITY}</snmp_community>
-                     <snmp_oid>1.3.6.1.4.1.232.3.2.2.1.1.2.{#SNMPINDEX}</snmp_oid>
-                     <key>system.hw.diskarray.model[cpqDaCntlrModel.{#SNMPINDEX}]</key>
-                     <delay>1d</delay>
-                     <trends>0d</trends>
-                     <description>MIB: CPQIDA-MIB&#13;
+                            <applications>
+                                <application>
+                                    <name>Disk Arrays</name>
+                                </application>
+                            </applications>
+                            <valuemap>
+                                <name>CPQIDA-MIB::cpqDaAccelStatus</name>
+                            </valuemap>
+                            <trigger_prototypes>
+                                <trigger_prototype>
+                                    <expression>{last()}&gt;=4</expression>
+                                    <recovery_mode>RECOVERY_EXPRESSION</recovery_mode>
+                                    <recovery_expression>{last()}&lt;4</recovery_expression>
+                                    <name>Slot {#CACHE_CNTRL_INDEX}: Disk array cache controller is in critical state!</name>
+                                    <priority>HIGH</priority>
+                                    <description>Last value: {ITEM.LASTVALUE1}.&#13;
+Please check the device for faults</description>
+                                </trigger_prototype>
+                            </trigger_prototypes>
+                        </item_prototype>
+                    </item_prototypes>
+                </discovery_rule>
+                <discovery_rule>
+                    <name>Array Controller Discovery</name>
+                    <type>SNMP_AGENT</type>
+                    <snmp_oid>discovery[{#SNMPVALUE},1.3.6.1.4.1.232.3.2.2.1.1.1,{#CNTLR_SLOT},1.3.6.1.4.1.232.3.2.2.1.1.5,{#CNTLR_LOCATION},1.3.6.1.4.1.232.3.2.2.1.1.20]</snmp_oid>
+                    <key>array.discovery</key>
+                    <delay>1h</delay>
+                    <description>Scanning table of Array controllers: CPQIDA-MIB::cpqDaCntlrTable</description>
+                    <item_prototypes>
+                        <item_prototype>
+                            <name>{#CNTLR_LOCATION}: Array controller revision (firmware)</name>
+                            <type>SNMP_AGENT</type>
+                            <snmp_oid>1.3.6.1.4.1.232.3.2.2.1.1.3.{#SNMPINDEX}</snmp_oid>
+                            <key>system.hw.diskarray.firmware[cpqDaCntlrFWRev.{#SNMPINDEX}]</key>
+                            <delay>1d</delay>
+                            <trends>0</trends>
+                            <value_type>TEXT</value_type>
+                            <description>CPQIDA-MIB: Array Controller Firmware Revision. The firmware revision of the drive array controller. This value can be used to help identify a particular revision of the controller. For B-Series controllers this value is the RAID Stack Revision that is running and this value may change when upgrading or downgrading the operating system device driver.</description>
+                            <applications>
+                                <application>
+                                    <name>Disk Arrays</name>
+                                </application>
+                                <application>
+                                    <name>Firmware</name>
+                                </application>
+                            </applications>
+                        </item_prototype>
+                        <item_prototype>
+                            <name>{#CNTLR_LOCATION}: Array controller revision (hardware)</name>
+                            <type>SNMP_AGENT</type>
+                            <snmp_oid>1.3.6.1.4.1.232.3.2.2.1.1.7.{#SNMPINDEX}</snmp_oid>
+                            <key>system.hw.diskarray.hardware[cpqDaCntlrProductRev.{#SNMPINDEX}]</key>
+                            <delay>1d</delay>
+                            <trends>0</trends>
+                            <value_type>TEXT</value_type>
+                            <description>CPQIDA-MIB: Array Controller Product Revision. The Product Revision of the drive array controller. This value can be used to further identify a particular revision of the controller model. This will be one character ASCII value that is zero terminated. If the controller model or the firmware does not support the product revision, the agents will return a NULL string.</description>
+                            <applications>
+                                <application>
+                                    <name>Disk Arrays</name>
+                                </application>
+                                <application>
+                                    <name>Firmware</name>
+                                </application>
+                            </applications>
+                        </item_prototype>
+                        <item_prototype>
+                            <name>{#CNTLR_LOCATION}: Array controller model</name>
+                            <type>SNMP_AGENT</type>
+                            <snmp_oid>1.3.6.1.4.1.232.3.2.2.1.1.2.{#SNMPINDEX}</snmp_oid>
+                            <key>system.hw.diskarray.model[cpqDaCntlrModel.{#SNMPINDEX}]</key>
+                            <delay>1d</delay>
+                            <history>30d</history>
+                            <trends>0d</trends>
+                            <description>MIB: CPQIDA-MIB&#13;
 Array Controller Model. The type of controller card.</description>
-                     <applications>
-                        <application>
-                           <name>Disk arrays</name>
-                        </application>
-                     </applications>
-                     <valuemap>
-                        <name>CPQIDA-MIB::cpqDaCntlrModel</name>
-                     </valuemap>
-                  </item_prototype>
-                  <item_prototype>
-                     <name>{#CNTLR_LOCATION}: Disk array controller status</name>
-                     <type>SNMPV2</type>
-                     <snmp_community>{$SNMP_COMMUNITY}</snmp_community>
-                     <snmp_oid>1.3.6.1.4.1.232.3.2.2.1.1.6.{#SNMPINDEX}</snmp_oid>
-                     <key>system.hw.diskarray.status[cpqDaCntlrCondition.{#SNMPINDEX}]</key>
-                     <history>1w</history>
-                     <trends>0d</trends>
-                     <description>MIB: CPQIDA-MIB&#13;
+                            <applications>
+                                <application>
+                                    <name>Disk Arrays</name>
+                                </application>
+                            </applications>
+                            <valuemap>
+                                <name>CPQIDA-MIB::cpqDaCntlrModel</name>
+                            </valuemap>
+                        </item_prototype>
+                        <item_prototype>
+                            <name>{#CNTLR_LOCATION}: Array controller serial</name>
+                            <type>SNMP_AGENT</type>
+                            <snmp_oid>1.3.6.1.4.1.232.3.2.2.1.1.15.{#SNMPINDEX}</snmp_oid>
+                            <key>system.hw.diskarray.serial[cpqDaCntlrSerialNumber.{#SNMPINDEX}]</key>
+                            <delay>1d</delay>
+                            <trends>0</trends>
+                            <value_type>TEXT</value_type>
+                            <description>CPQIDA-MIB::cpqDaCntlrSerialNumber&#13;
+&#13;
+Array Controller Serial Number. The serial number of the array controller. This field will be a null (size 0) string if the controller does not support serial number.</description>
+                            <applications>
+                                <application>
+                                    <name>Disk Arrays</name>
+                                </application>
+                                <application>
+                                    <name>Inventory</name>
+                                </application>
+                            </applications>
+                        </item_prototype>
+                        <item_prototype>
+                            <name>{#CNTLR_LOCATION}: Array controller status</name>
+                            <type>SNMP_AGENT</type>
+                            <snmp_oid>1.3.6.1.4.1.232.3.2.2.1.1.6.{#SNMPINDEX}</snmp_oid>
+                            <key>system.hw.diskarray.status[cpqDaCntlrCondition.{#SNMPINDEX}]</key>
+                            <delay>5m</delay>
+                            <history>1w</history>
+                            <trends>0d</trends>
+                            <description>MIB: CPQIDA-MIB&#13;
 This value represents the overall condition of this controller,&#13;
 and any associated logical drives,physical drives, and array accelerators.</description>
-                     <applications>
-                        <application>
-                           <name>Disk arrays</name>
-                        </application>
-                     </applications>
-                     <valuemap>
-                        <name>CPQSINFO-MIB::status</name>
-                     </valuemap>
-                     <trigger_prototypes>
-                        <trigger_prototype>
-                           <expression>{count(#1,{$DISK_ARRAY_CRIT_STATUS},eq)}=1</expression>
-                           <name>{#CNTLR_LOCATION}: Disk array controller is in critical state</name>
-                           <opdata>Current state: {ITEM.LASTVALUE1}</opdata>
-                           <priority>HIGH</priority>
-                           <description>Please check the device for faults</description>
-                        </trigger_prototype>
-                        <trigger_prototype>
-                           <expression>{count(#1,{$DISK_ARRAY_WARN_STATUS},eq)}=1</expression>
-                           <name>{#CNTLR_LOCATION}: Disk array controller is in warning state</name>
-                           <opdata>Current state: {ITEM.LASTVALUE1}</opdata>
-                           <priority>AVERAGE</priority>
-                           <description>Please check the device for faults</description>
-                           <dependencies>
-                              <dependency>
-                                 <name>{#CNTLR_LOCATION}: Disk array controller is in critical state</name>
-                                 <expression>{Template Server HP iLO SNMPv2:system.hw.diskarray.status[cpqDaCntlrCondition.{#SNMPINDEX}].count(#1,{$DISK_ARRAY_CRIT_STATUS},eq)}=1</expression>
-                              </dependency>
-                           </dependencies>
-                        </trigger_prototype>
-                     </trigger_prototypes>
-                  </item_prototype>
-               </item_prototypes>
-            </discovery_rule>
-            <discovery_rule>
-               <name>FAN Discovery</name>
-               <type>SNMPV2</type>
-               <snmp_community>{$SNMP_COMMUNITY}</snmp_community>
-               <snmp_oid>discovery[{#SNMPVALUE},1.3.6.1.4.1.232.6.2.6.7.1.9]</snmp_oid>
-               <key>fan.discovery</key>
-               <delay>1h</delay>
-               <description>CPQHLTH-MIB::cpqHeFltTolFanCondition</description>
-               <item_prototypes>
-                  <item_prototype>
-                     <name>Fan {#SNMPINDEX}: Fan status</name>
-                     <type>SNMPV2</type>
-                     <snmp_community>{$SNMP_COMMUNITY}</snmp_community>
-                     <snmp_oid>1.3.6.1.4.1.232.6.2.6.7.1.9.{#SNMPINDEX}</snmp_oid>
-                     <key>sensor.fan.status[cpqHeFltTolFanCondition.{#SNMPINDEX}]</key>
-                     <delay>3m</delay>
-                     <history>2w</history>
-                     <trends>0d</trends>
-                     <description>MIB: CPQHLTH-MIB&#13;
+                            <applications>
+                                <application>
+                                    <name>Disk Arrays</name>
+                                </application>
+                            </applications>
+                            <valuemap>
+                                <name>CPQSINFO-MIB::status</name>
+                            </valuemap>
+                            <trigger_prototypes>
+                                <trigger_prototype>
+                                    <expression>{count(#1,{$DISK_ARRAY_CRIT_STATUS},eq)}=1</expression>
+                                    <name>{#CNTLR_LOCATION}: Disk array controller is in critical state</name>
+                                    <priority>HIGH</priority>
+                                    <description>Last value: {ITEM.LASTVALUE1}.&#13;
+Please check the device for faults</description>
+                                </trigger_prototype>
+                                <trigger_prototype>
+                                    <expression>{count(#1,{$DISK_ARRAY_WARN_STATUS},eq)}=1</expression>
+                                    <name>{#CNTLR_LOCATION}: Disk array controller is in warning state</name>
+                                    <priority>AVERAGE</priority>
+                                    <description>Last value: {ITEM.LASTVALUE1}.&#13;
+Please check the device for faults</description>
+                                    <dependencies>
+                                        <dependency>
+                                            <name>{#CNTLR_LOCATION}: Disk array controller is in critical state</name>
+                                            <expression>{Template Server HP iLO SNMPv2:system.hw.diskarray.status[cpqDaCntlrCondition.{#SNMPINDEX}].count(#1,{$DISK_ARRAY_CRIT_STATUS},eq)}=1</expression>
+                                        </dependency>
+                                    </dependencies>
+                                </trigger_prototype>
+                            </trigger_prototypes>
+                        </item_prototype>
+                    </item_prototypes>
+                </discovery_rule>
+                <discovery_rule>
+                    <name>Firmware Version Discovery</name>
+                    <type>SNMP_AGENT</type>
+                    <snmp_oid>discovery[{#SNMPVALUE},1.3.6.1.4.1.232.11.2.14.1.1.1]</snmp_oid>
+                    <key>cpqFwVer.dicovery</key>
+                    <delay>1h</delay>
+                    <description>Scanning of Firmware entry table CPQHOST-MIB::cpqHoFwVerEntry</description>
+                    <item_prototypes>
+                        <item_prototype>
+                            <name>Firmware Device ({#SNMPINDEX}) Version Key:</name>
+                            <type>SNMP_AGENT</type>
+                            <snmp_oid>1.3.6.1.4.1.232.11.2.14.1.1.8.{#SNMPINDEX}</snmp_oid>
+                            <key>system.fw.device.keyString[cpqHoFwVerKeyString.{#SNMPINDEX}]</key>
+                            <delay>1d</delay>
+                            <trends>0</trends>
+                            <value_type>TEXT</value_type>
+                            <description>CPQHOST-MIB::cpqHoFwVerKeyString&#13;
+Firmware Version Key String. This field is differentiate devices of the same type.</description>
+                            <applications>
+                                <application>
+                                    <name>Firmware</name>
+                                </application>
+                            </applications>
+                        </item_prototype>
+                        <item_prototype>
+                            <name>Firmware Device ({#SNMPINDEX}) Location:</name>
+                            <type>SNMP_AGENT</type>
+                            <snmp_oid>1.3.6.1.4.1.232.11.2.14.1.1.6.{#SNMPINDEX}</snmp_oid>
+                            <key>system.fw.device.locale[cpqHoFwVerLocation.{#SNMPINDEX}]</key>
+                            <delay>1d</delay>
+                            <trends>0</trends>
+                            <value_type>TEXT</value_type>
+                            <applications>
+                                <application>
+                                    <name>Firmware</name>
+                                </application>
+                            </applications>
+                        </item_prototype>
+                        <item_prototype>
+                            <name>Firmware Device ({#SNMPINDEX}) Name:</name>
+                            <type>SNMP_AGENT</type>
+                            <snmp_oid>1.3.6.1.4.1.232.11.2.14.1.1.4.{#SNMPINDEX}</snmp_oid>
+                            <key>system.fw.device.name[cpqHoFwVerDisplayName.{#SNMPINDEX}]</key>
+                            <delay>1d</delay>
+                            <trends>0</trends>
+                            <value_type>TEXT</value_type>
+                            <description>CPQHOST-MIB::cpqHoFwVerDisplayName3&#13;
+Firmware Version Device Display Name. This is the display name of the device containing the firmware.</description>
+                            <applications>
+                                <application>
+                                    <name>Firmware</name>
+                                </application>
+                            </applications>
+                        </item_prototype>
+                        <item_prototype>
+                            <name>Firmware Device ({#SNMPINDEX}) Type:</name>
+                            <type>SNMP_AGENT</type>
+                            <snmp_oid>1.3.6.1.4.1.232.11.2.14.1.1.3.{#SNMPINDEX}</snmp_oid>
+                            <key>system.fw.device.type[cpqHoFwVerDeviceType.{#SNMPINDEX}]</key>
+                            <delay>1d</delay>
+                            <trends>0d</trends>
+                            <description>CPQHOST-MIB:cpqHoFwVerDeviceType&#13;
+&#13;
+other(1), internalArrayController(2), fibreArrayController(3), scsiController(4), fibreChannelTapeController(5), modularDataRouter(6), ideCdRomDrive(7), ideDiskDrive(8), scsiCdRom-ScsiAttached(9), scsiDiskDrive-ScsiAttached(10), scsiTapeDrive-ScsiAttached(11), scsiTapeLibrary-ScsiAttached(12), scsiDiskDrive-ArrayAttached(13), scsiTapeDrive-ArrayAttached(14), scsiTapeLibrary-ArrayAttached(15), scsiDiskDrive-FibreAttached(16), scsiTapeDrive-FibreAttached(17), scsiTapeLibrary-FibreAttached(18), scsiEnclosureBackplaneRom-ScsiAttached(19), scsiEnclosureBackplaneRom-ArrayAttached(20), scsiEnclosureBackplaneRom-FibreAttached(21), scsiEnclosureBackplaneRom-ra4x00(22), systemRom(23), networkInterfaceController(24), remoteInsightBoard(25)</description>
+                            <applications>
+                                <application>
+                                    <name>Firmware</name>
+                                </application>
+                            </applications>
+                            <valuemap>
+                                <name>CPQHOST-MIB::cpqHoFwVerDeviceType</name>
+                            </valuemap>
+                        </item_prototype>
+                        <item_prototype>
+                            <name>Firmware Device ({#SNMPINDEX}) Update Method:</name>
+                            <type>SNMP_AGENT</type>
+                            <snmp_oid>1.3.6.1.4.1.232.11.2.14.1.1.9.{#SNMPINDEX}</snmp_oid>
+                            <key>system.fw.device.updateMethod[cpqHoFwVerUpdateMethod.{#SNMPINDEX}]</key>
+                            <delay>1d</delay>
+                            <description>CPQHOST::cpqHoFwVerUpdateMethod&#13;
+Firmware Version update method.</description>
+                            <applications>
+                                <application>
+                                    <name>Firmware</name>
+                                </application>
+                            </applications>
+                            <valuemap>
+                                <name>CPQHOST-MIB::cpqHoFwVerUpdateMethod</name>
+                            </valuemap>
+                        </item_prototype>
+                        <item_prototype>
+                            <name>Firmware Device ({#SNMPINDEX}) Version:</name>
+                            <type>SNMP_AGENT</type>
+                            <snmp_oid>1.3.6.1.4.1.232.11.2.14.1.1.5.{#SNMPINDEX}</snmp_oid>
+                            <key>system.fw.device.version[cpqHoFwVerVersion.{#SNMPINDEX}]</key>
+                            <delay>1d</delay>
+                            <trends>0</trends>
+                            <value_type>TEXT</value_type>
+                            <applications>
+                                <application>
+                                    <name>Firmware</name>
+                                </application>
+                            </applications>
+                        </item_prototype>
+                    </item_prototypes>
+                </discovery_rule>
+                <discovery_rule>
+                    <name>Memory Discovery</name>
+                    <type>SNMP_AGENT</type>
+                    <snmp_oid>discovery[{#SLOT},1.3.6.1.4.1.232.6.2.14.13.1.1,{#CPU},1.3.6.1.4.1.232.6.2.14.13.1.3,{#LOCALE},1.3.6.1.4.1.232.6.2.14.13.1.13]</snmp_oid>
+                    <key>cpqHeMem.discovery</key>
+                    <delay>1h</delay>
+                    <lifetime>8h</lifetime>
+                    <item_prototypes>
+                        <item_prototype>
+                            <name>System: Memory Slot {#LOCALE} Module ECC Status :</name>
+                            <type>SNMP_AGENT</type>
+                            <snmp_oid>1.3.6.1.4.1.232.6.2.14.13.1.20.{#SNMPINDEX}</snmp_oid>
+                            <key>system.mem.slot.eccStatus[ cpqHeResMem2ModuleCondition.{#SNMPINDEX}]</key>
+                            <description>CPQHLTH-MIB::cpqHeResMem2ModuleCondition&#13;
+&#13;
+This provides the current status of the correctable memory errors for this memory module. The following status values are supported: other(1): ECC is not supported on this memory module or the condition could not be determined. ok(2): The memory module is operating normally. degraded(3): The memory module is correctable error count has exceeded threshold or a configuration error has been detected. degradedModuleIndexUnknown(4): The correctable error count has exceeded threshold. The module number not available.</description>
+                            <applications>
+                                <application>
+                                    <name>Memory</name>
+                                </application>
+                            </applications>
+                            <valuemap>
+                                <name>CPQHLTH-MIB::cpqHeResMem2ModuleCondition</name>
+                            </valuemap>
+                            <trigger_prototypes>
+                                <trigger_prototype>
+                                    <expression>{last()}&gt;2</expression>
+                                    <recovery_mode>RECOVERY_EXPRESSION</recovery_mode>
+                                    <recovery_expression>{last()}&lt;=2</recovery_expression>
+                                    <name>System: Memory Slot {#LOCALE} Module ECC Status is degraded</name>
+                                    <priority>WARNING</priority>
+                                    <manual_close>YES</manual_close>
+                                </trigger_prototype>
+                            </trigger_prototypes>
+                        </item_prototype>
+                        <item_prototype>
+                            <name>System: Memory Slot {#LOCALE} Module Frequency :</name>
+                            <type>SNMP_AGENT</type>
+                            <snmp_oid>1.3.6.1.4.1.232.6.2.14.13.1.14.{#SNMPINDEX}</snmp_oid>
+                            <key>system.mem.slot.frequency[ cpqHeResMem2ModuleFrequency.{#SNMPINDEX}]</key>
+                            <delay>1d</delay>
+                            <history>2w</history>
+                            <trends>0</trends>
+                            <value_type>TEXT</value_type>
+                            <description>CPQHLTH-MIB::cpqHeResMem2ModuleFrequency&#13;
+&#13;
+The memory module maximum frequency in MHz. The value zero (0) will be given if the module frequency cannot be determined.</description>
+                            <applications>
+                                <application>
+                                    <name>Memory</name>
+                                </application>
+                            </applications>
+                            <preprocessing>
+                                <step>
+                                    <type>REGEX</type>
+                                    <params>(?=^\d+$)(^\d+$)
+\1Mhz</params>
+                                </step>
+                            </preprocessing>
+                        </item_prototype>
+                        <item_prototype>
+                            <name>System: Memory Slot {#LOCALE} Module Size :</name>
+                            <type>SNMP_AGENT</type>
+                            <snmp_oid>1.3.6.1.4.1.232.6.2.14.13.1.6.{#SNMPINDEX}</snmp_oid>
+                            <key>system.mem.slot.size[ cpqHeResMem2ModuleSize.{#SNMPINDEX}]</key>
+                            <delay>1d</delay>
+                            <history>30d</history>
+                            <units>B</units>
+                            <description>CPQHLTH-MIB::cpqHeResMem2ModuleSize&#13;
+&#13;
+Module memory size in kilobytes. A kilobyte of memory is defined as 1024 bytes. A size of 0 indicates the module is not present.</description>
+                            <applications>
+                                <application>
+                                    <name>Memory</name>
+                                </application>
+                            </applications>
+                            <preprocessing>
+                                <step>
+                                    <type>MULTIPLIER</type>
+                                    <params>1024</params>
+                                </step>
+                            </preprocessing>
+                        </item_prototype>
+                        <item_prototype>
+                            <name>System: Memory Slot {#LOCALE} Smart Memory :</name>
+                            <type>SNMP_AGENT</type>
+                            <snmp_oid>1.3.6.1.4.1.232.6.2.14.13.1.22.{#SNMPINDEX}</snmp_oid>
+                            <key>system.mem.slot.smartMemory[cpqHeResMem2ModuleSmartMemory.{#SNMPINDEX}]</key>
+                            <delay>1d</delay>
+                            <history>2w</history>
+                            <trends>0d</trends>
+                            <description>CPQHLTH-MIB::cpqHeResMem2ModuleSmartMemory&#13;
+&#13;
+This indicates whether the DIMM slot is populated with an HP Smart Memory DIMM. The following values are supported: other(1): HP SmartMemory not supported in this device. notHPSmartMemory(2): HP SmartMemory is NOT installed in DIMM slot (includes the case where the DIMM slot is not populated). isHPSmartMemory(3): HP SmartMemory is installed in DIMM slot.</description>
+                            <applications>
+                                <application>
+                                    <name>Memory</name>
+                                </application>
+                            </applications>
+                            <valuemap>
+                                <name>CPQHLTH-MIB::cpqHeResMem2ModuleSmartMemory</name>
+                            </valuemap>
+                        </item_prototype>
+                        <item_prototype>
+                            <name>System: Memory Slot {#LOCALE} Module Status :</name>
+                            <type>SNMP_AGENT</type>
+                            <snmp_oid>1.3.6.1.4.1.232.6.2.14.13.1.19.{#SNMPINDEX}</snmp_oid>
+                            <key>system.mem.slot.status[ cpqHeResMem2ModuleStatus.{#SNMPINDEX}]</key>
+                            <description>CPQHLTH-MIB::cpqHeResMem2ModuleStatus&#13;
+&#13;
+This provides the current status of the correctable memory errors for this memory module. The following status values are supported: other(1): The status is unknown or could not be determined. notPresent(2): The memory module is not present or is un-initialized. present(3): The memory module is present but not in use. good(4): The memory module is present and in use. The corrected error threshold has not been exceeded. add(5): The memory module has been added, but is not yet in use. upgraded(6): The memory module has been upgraded, but the memory is not yet in use. missing(7): An expected memory module is missing. doesNotMatch(8): The memory module does not match the other memory modules within the bank. notSupported(9): The memory module is not supported. badConfig(10): The memory module violates the add/upgrade configuration rules. degraded(11): The memory module's correctable error count has exceeded threshold. spare(12): The memory module is configured as a spare. partial(13): The memory module is present and is partially in use.</description>
+                            <applications>
+                                <application>
+                                    <name>Memory</name>
+                                </application>
+                            </applications>
+                            <valuemap>
+                                <name>CPQHLTH-MIB::cpqHeResMem2ModuleStatus</name>
+                            </valuemap>
+                            <trigger_prototypes>
+                                <trigger_prototype>
+                                    <expression>{last()}&gt;6</expression>
+                                    <recovery_mode>RECOVERY_EXPRESSION</recovery_mode>
+                                    <recovery_expression>{last()}&lt;=6</recovery_expression>
+                                    <name>System: Memory Slot {#LOCALE} Module Status is not normal</name>
+                                    <priority>WARNING</priority>
+                                    <manual_close>YES</manual_close>
+                                </trigger_prototype>
+                            </trigger_prototypes>
+                        </item_prototype>
+                    </item_prototypes>
+                </discovery_rule>
+                <discovery_rule>
+                    <name>FAN Discovery</name>
+                    <type>SNMP_AGENT</type>
+                    <snmp_oid>discovery[{#CHASSIS},1.3.6.1.4.1.232.6.2.6.7.1.1,{#FAN},1.3.6.1.4.1.232.6.2.6.7.1.2]</snmp_oid>
+                    <key>fan.discovery</key>
+                    <delay>1h</delay>
+                    <description>CPQHLTH-MIB::cpqHeFltTolFanCondition</description>
+                    <item_prototypes>
+                        <item_prototype>
+                            <name>System: Chassis {#CHASSIS} , Fan {#FAN}  Hot Pluggable:</name>
+                            <type>SNMP_AGENT</type>
+                            <snmp_oid>1.3.6.1.4.1.232.6.2.6.7.1.10.{#SNMPINDEX}</snmp_oid>
+                            <key>sensor.fan.hotPluggable[cpqHeFltTolFanHotPlug.{#SNMPINDEX}]</key>
+                            <delay>1d</delay>
+                            <history>2w</history>
+                            <trends>0d</trends>
+                            <description>CPQHLTH-MIB::cpqHeFltTolFanHotPlug&#13;
+&#13;
+This indicates if the fan is capable of being removed and/or inserted while the system is in an operational state. If the value is hotPluggable(3), the fan can be safely removed if and only if the cpqHeFltTolFanRedundant field is in a redundant(3) state. This value will be one of the following: other(1) The state could not be determined. nonHotPluggable(2) The fan is not hot plug capable. hotPluggable(3) The fan is hot plug capable and can be removed if the system is operating in a redundant state. A fan may be added to an empty fan bay.</description>
+                            <applications>
+                                <application>
+                                    <name>Fans</name>
+                                </application>
+                            </applications>
+                            <valuemap>
+                                <name>CPQHLTH-MIB::cpqHeFltTolFanHotPlug</name>
+                            </valuemap>
+                        </item_prototype>
+                        <item_prototype>
+                            <name>System: Chassis {#CHASSIS} , Fan {#FAN}  Redundant Partner:</name>
+                            <type>SNMP_AGENT</type>
+                            <snmp_oid>1.3.6.1.4.1.232.6.2.6.7.1.8.{#SNMPINDEX}</snmp_oid>
+                            <key>sensor.fan.redundantPartner[cpqHeFltTolFanRedundantPartner.{#SNMPINDEX}]</key>
+                            <delay>1d</delay>
+                            <history>2w</history>
+                            <description>CPQHLTH-MIB::cpqHeFltTolFanRedundantPartner&#13;
+&#13;
+This specifies the index of the redundant partner. A value of zero will be used if there is no redundant partner.</description>
+                            <applications>
+                                <application>
+                                    <name>Fans</name>
+                                </application>
+                            </applications>
+                        </item_prototype>
+                        <item_prototype>
+                            <name>System: Chassis {#CHASSIS} , Fan {#FAN} Redundant:</name>
+                            <type>SNMP_AGENT</type>
+                            <snmp_oid>1.3.6.1.4.1.232.6.2.6.7.1.7.{#SNMPINDEX}</snmp_oid>
+                            <key>sensor.fan.redundant[cpqHeFltTolFanRedundant.{#SNMPINDEX}]</key>
+                            <delay>1d</delay>
+                            <history>2w</history>
+                            <trends>0d</trends>
+                            <description>CPQHLTH-MIB::cpqHeFltTolFanRedundant&#13;
+&#13;
+This specifies if the fan is in a redundant configuration.&#13;
+other(1), notRedundant(2), redundant(3)</description>
+                            <applications>
+                                <application>
+                                    <name>Fans</name>
+                                </application>
+                            </applications>
+                            <valuemap>
+                                <name>CPQHLTH-MIB::cpqHeFltTolFanRedundant</name>
+                            </valuemap>
+                        </item_prototype>
+                        <item_prototype>
+                            <name>System: Chassis {#CHASSIS} , Fan {#FAN}  Status:</name>
+                            <type>SNMP_AGENT</type>
+                            <snmp_oid>1.3.6.1.4.1.232.6.2.6.7.1.9.{#SNMPINDEX}</snmp_oid>
+                            <key>sensor.fan.status[cpqHeFltTolFanCondition.{#SNMPINDEX}]</key>
+                            <delay>3m</delay>
+                            <history>2w</history>
+                            <trends>0d</trends>
+                            <description>MIB: CPQHLTH-MIB&#13;
+&#13;
 The condition of the fan.&#13;
 This value will be one of the following:&#13;
 other(1)  Fan status detection is not supported by this system or driver.&#13;
 ok(2)  The fan is operating properly.&#13;
-degraded(2)  A redundant fan is not operating properly.&#13;
+degraded(3)  A redundant fan is not operating properly.&#13;
 failed(4)  A non-redundant fan is not operating properly.</description>
-                     <applications>
-                        <application>
-                           <name>Fans</name>
-                        </application>
-                     </applications>
-                     <valuemap>
-                        <name>CPQSINFO-MIB::status</name>
-                     </valuemap>
-                     <trigger_prototypes>
-                        <trigger_prototype>
-                           <expression>{count(#1,{$FAN_CRIT_STATUS},eq)}=1</expression>
-                           <name>Fan {#SNMPINDEX}: Fan is in critical state</name>
-                           <opdata>Current state: {ITEM.LASTVALUE1}</opdata>
-                           <priority>AVERAGE</priority>
-                           <description>Please check the fan unit</description>
-                        </trigger_prototype>
-                        <trigger_prototype>
-                           <expression>{count(#1,{$FAN_WARN_STATUS},eq)}=1</expression>
-                           <name>Fan {#SNMPINDEX}: Fan is in warning state</name>
-                           <opdata>Current state: {ITEM.LASTVALUE1}</opdata>
-                           <priority>WARNING</priority>
-                           <description>Please check the fan unit</description>
-                           <dependencies>
-                              <dependency>
-                                 <name>Fan {#SNMPINDEX}: Fan is in critical state</name>
-                                 <expression>{Template Server HP iLO SNMPv2:sensor.fan.status[cpqHeFltTolFanCondition.{#SNMPINDEX}].count(#1,{$FAN_CRIT_STATUS},eq)}=1</expression>
-                              </dependency>
-                           </dependencies>
-                        </trigger_prototype>
-                     </trigger_prototypes>
-                  </item_prototype>
-               </item_prototypes>
-            </discovery_rule>
-            <discovery_rule>
-               <name>Physical Disk Discovery</name>
-               <type>SNMPV2</type>
-               <snmp_community>{$SNMP_COMMUNITY}</snmp_community>
-               <snmp_oid>discovery[{#SNMPVALUE},1.3.6.1.4.1.232.3.2.5.1.1.5,{#DISK_LOCATION},1.3.6.1.4.1.232.3.2.5.1.1.64]</snmp_oid>
-               <key>physicalDisk.discovery</key>
-               <delay>1h</delay>
-               <description>Scanning  table of physical drive entries CPQIDA-MIB::cpqDaPhyDrvTable.</description>
-               <item_prototypes>
-                  <item_prototype>
-                     <name>{#DISK_LOCATION}: Physical disk media type</name>
-                     <type>SNMPV2</type>
-                     <snmp_community>{$SNMP_COMMUNITY}</snmp_community>
-                     <snmp_oid>1.3.6.1.4.1.232.3.2.5.1.1.69.{#SNMPINDEX}</snmp_oid>
-                     <key>system.hw.physicaldisk.media_type[cpqDaPhyDrvMediaType.{#SNMPINDEX}]</key>
-                     <delay>1h</delay>
-                     <history>2w</history>
-                     <trends>0d</trends>
-                     <description>MIB: CPQIDA-MIB&#13;
+                            <applications>
+                                <application>
+                                    <name>Fans</name>
+                                </application>
+                            </applications>
+                            <valuemap>
+                                <name>CPQSINFO-MIB::status</name>
+                            </valuemap>
+                            <trigger_prototypes>
+                                <trigger_prototype>
+                                    <expression>{last()}=4</expression>
+                                    <recovery_mode>RECOVERY_EXPRESSION</recovery_mode>
+                                    <recovery_expression>{last()}&lt;&gt;4</recovery_expression>
+                                    <name>System: Chassis {#CHASSIS} , Fan {#FAN}  is in critical state</name>
+                                    <priority>HIGH</priority>
+                                    <description>Last value: {ITEM.LASTVALUE1}.&#13;
+Please check the fan unit</description>
+                                </trigger_prototype>
+                                <trigger_prototype>
+                                    <expression>{last()}=3</expression>
+                                    <recovery_mode>RECOVERY_EXPRESSION</recovery_mode>
+                                    <recovery_expression>{last()}&lt;&gt;3</recovery_expression>
+                                    <name>System: Chassis {#CHASSIS} , Fan {#FAN}  is in warning state</name>
+                                    <priority>WARNING</priority>
+                                    <description>Last value: {ITEM.LASTVALUE1}.&#13;
+Please check the fan unit</description>
+                                </trigger_prototype>
+                            </trigger_prototypes>
+                        </item_prototype>
+                        <item_prototype>
+                            <name>System: Chassis {#CHASSIS} , Fan {#FAN}  Type:</name>
+                            <type>SNMP_AGENT</type>
+                            <snmp_oid>1.3.6.1.4.1.232.6.2.6.7.1.5.{#SNMPINDEX}</snmp_oid>
+                            <key>sensor.fan.type[cpqHeFltTolFanType.{#SNMPINDEX}]</key>
+                            <delay>1d</delay>
+                            <history>2w</history>
+                            <trends>0d</trends>
+                            <description>CPQHLTH-MIB::cpqHeFltTolFanType&#13;
+&#13;
+This specifies the type of fan. other(1) The type of fan could not be determined. tachOutput(2) The fan can increase speed for greater cooling. Implies spin detect. spinDetect(3) The fan can detect when the fan stops spinning.</description>
+                            <applications>
+                                <application>
+                                    <name>Fans</name>
+                                </application>
+                            </applications>
+                            <valuemap>
+                                <name>CPQHLTH-MIB::cpqHeFltTolFanType</name>
+                            </valuemap>
+                        </item_prototype>
+                    </item_prototypes>
+                </discovery_rule>
+                <discovery_rule>
+                    <name>Physical Disk Discovery</name>
+                    <type>SNMP_AGENT</type>
+                    <snmp_oid>discovery[{#SNMPVALUE},1.3.6.1.4.1.232.3.2.5.1.1.5,{#DISK_LOCATION},1.3.6.1.4.1.232.3.2.5.1.1.64]</snmp_oid>
+                    <key>physicalDisk.discovery</key>
+                    <delay>1h</delay>
+                    <description>Scanning  table of physical drive entries CPQIDA-MIB::cpqDaPhyDrvTable.</description>
+                    <item_prototypes>
+                        <item_prototype>
+                            <name>{#DISK_LOCATION}: Drive revision (firmware)</name>
+                            <type>SNMP_AGENT</type>
+                            <snmp_oid>1.3.6.1.4.1.232.3.2.5.1.1.4.{#SNMPINDEX}</snmp_oid>
+                            <key>system.hw.physicaldisk.firmware[cpqDaPhyDrvFWRev.{#SNMPINDEX}]</key>
+                            <delay>1d</delay>
+                            <history>30d</history>
+                            <trends>0</trends>
+                            <value_type>TEXT</value_type>
+                            <description>MIB: CPQIDA-MIB&#13;
+Physical Drive Firmware Revision. This shows the physical drive revision number. If the firmware revision is not present, you have not properly initialized the drive array.</description>
+                            <applications>
+                                <application>
+                                    <name>Firmware</name>
+                                </application>
+                                <application>
+                                    <name>Physical Disks</name>
+                                </application>
+                            </applications>
+                        </item_prototype>
+                        <item_prototype>
+                            <name>{#DISK_LOCATION}: Drive media type</name>
+                            <type>SNMP_AGENT</type>
+                            <snmp_oid>1.3.6.1.4.1.232.3.2.5.1.1.69.{#SNMPINDEX}</snmp_oid>
+                            <key>system.hw.physicaldisk.media_type[cpqDaPhyDrvMediaType.{#SNMPINDEX}]</key>
+                            <delay>1h</delay>
+                            <history>2w</history>
+                            <trends>0d</trends>
+                            <description>MIB: CPQIDA-MIB&#13;
 Drive Array Physical Drive Media Type.The following values are defined:&#13;
 other(1)  The instrument agent is unable to determine the physical drive’s media type.&#13;
 rotatingPlatters(2)  The physical drive media is composed of rotating platters.&#13;
 solidState(3)  The physical drive media is composed of solid state electronics.</description>
-                     <applications>
-                        <application>
-                           <name>Physical disks</name>
-                        </application>
-                     </applications>
-                     <valuemap>
-                        <name>CPQIDA-MIB::cpqDaPhyDrvMediaType</name>
-                     </valuemap>
-                  </item_prototype>
-                  <item_prototype>
-                     <name>{#DISK_LOCATION}: Physical disk model name</name>
-                     <type>SNMPV2</type>
-                     <snmp_community>{$SNMP_COMMUNITY}</snmp_community>
-                     <snmp_oid>1.3.6.1.4.1.232.3.2.5.1.1.3.{#SNMPINDEX}</snmp_oid>
-                     <key>system.hw.physicaldisk.model[cpqDaPhyDrvModel.{#SNMPINDEX}]</key>
-                     <delay>1h</delay>
-                     <history>2w</history>
-                     <trends>0</trends>
-                     <value_type>CHAR</value_type>
-                     <description>MIB: CPQIDA-MIB&#13;
+                            <applications>
+                                <application>
+                                    <name>Physical Disks</name>
+                                </application>
+                            </applications>
+                            <valuemap>
+                                <name>CPQIDA-MIB::cpqDaPhyDrvMediaType</name>
+                            </valuemap>
+                        </item_prototype>
+                        <item_prototype>
+                            <name>{#DISK_LOCATION}: Drive model name</name>
+                            <type>SNMP_AGENT</type>
+                            <snmp_oid>1.3.6.1.4.1.232.3.2.5.1.1.3.{#SNMPINDEX}</snmp_oid>
+                            <key>system.hw.physicaldisk.model[cpqDaPhyDrvModel.{#SNMPINDEX}]</key>
+                            <delay>1h</delay>
+                            <history>2w</history>
+                            <trends>0</trends>
+                            <value_type>CHAR</value_type>
+                            <description>MIB: CPQIDA-MIB&#13;
 Physical Drive Model.This is a text description of the physical drive.&#13;
 The text that appears depends upon who manufactured the drive and the drive type.&#13;
 If a drive fails, note the model to identify the type of drive necessary for replacement.&#13;
 If a model number is not present, you may not have properly initialized the drive array to which the physical drive is attached for monitoring.</description>
-                     <applications>
-                        <application>
-                           <name>Physical disks</name>
-                        </application>
-                     </applications>
-                  </item_prototype>
-                  <item_prototype>
-                     <name>{#DISK_LOCATION}: Physical disk serial number</name>
-                     <type>SNMPV2</type>
-                     <snmp_community>{$SNMP_COMMUNITY}</snmp_community>
-                     <snmp_oid>1.3.6.1.4.1.232.3.2.5.1.1.51.{#SNMPINDEX}</snmp_oid>
-                     <key>system.hw.physicaldisk.serialnumber[cpqDaPhyDrvSerialNum.{#SNMPINDEX}]</key>
-                     <delay>1d</delay>
-                     <trends>0</trends>
-                     <value_type>CHAR</value_type>
-                     <description>MIB: CPQIDA-MIB&#13;
+                            <applications>
+                                <application>
+                                    <name>Physical Disks</name>
+                                </application>
+                            </applications>
+                        </item_prototype>
+                        <item_prototype>
+                            <name>{#DISK_LOCATION}: Drive serial number</name>
+                            <type>SNMP_AGENT</type>
+                            <snmp_oid>1.3.6.1.4.1.232.3.2.5.1.1.51.{#SNMPINDEX}</snmp_oid>
+                            <key>system.hw.physicaldisk.serialnumber[cpqDaPhyDrvSerialNum.{#SNMPINDEX}]</key>
+                            <delay>1d</delay>
+                            <history>30d</history>
+                            <trends>0</trends>
+                            <value_type>CHAR</value_type>
+                            <description>MIB: CPQIDA-MIB&#13;
 Physical Drive Serial Number.&#13;
 This is the serial number assigned to the physical drive.&#13;
 This value is based upon the serial number as returned by the SCSI inquiry command&#13;
 but may have been modified due to space limitations.  This can be used for identification purposes.</description>
-                     <applications>
-                        <application>
-                           <name>Physical disks</name>
-                        </application>
-                     </applications>
-                     <trigger_prototypes>
-                        <trigger_prototype>
-                           <expression>{diff()}=1 and {strlen()}&gt;0</expression>
-                           <name>{#DISK_LOCATION}: Disk has been replaced (new serial number received)</name>
-                           <priority>INFO</priority>
-                           <description>Disk serial number has changed. Ack to close</description>
-                           <manual_close>YES</manual_close>
-                        </trigger_prototype>
-                     </trigger_prototypes>
-                  </item_prototype>
-                  <item_prototype>
-                     <name>{#DISK_LOCATION}: Disk size</name>
-                     <type>SNMPV2</type>
-                     <snmp_community>{$SNMP_COMMUNITY}</snmp_community>
-                     <snmp_oid>1.3.6.1.4.1.232.3.2.5.1.1.45.{#SNMPINDEX}</snmp_oid>
-                     <key>system.hw.physicaldisk.size[cpqDaPhyDrvMediaType.{#SNMPINDEX}]</key>
-                     <delay>1h</delay>
-                     <history>2w</history>
-                     <trends>0d</trends>
-                     <units>B</units>
-                     <description>MIB: CPQIDA-MIB&#13;
+                            <applications>
+                                <application>
+                                    <name>Physical Disks</name>
+                                </application>
+                            </applications>
+                            <trigger_prototypes>
+                                <trigger_prototype>
+                                    <expression>{diff()}=1 and {strlen()}&gt;0</expression>
+                                    <recovery_mode>NONE</recovery_mode>
+                                    <name>{#DISK_LOCATION}: Disk has been replaced (new serial number received)</name>
+                                    <priority>INFO</priority>
+                                    <description>Last value: {ITEM.LASTVALUE1}.&#13;
+Disk serial number has changed. Ack to close</description>
+                                    <manual_close>YES</manual_close>
+                                </trigger_prototype>
+                            </trigger_prototypes>
+                        </item_prototype>
+                        <item_prototype>
+                            <name>{#DISK_LOCATION}: Drive size</name>
+                            <type>SNMP_AGENT</type>
+                            <snmp_oid>1.3.6.1.4.1.232.3.2.5.1.1.45.{#SNMPINDEX}</snmp_oid>
+                            <key>system.hw.physicaldisk.size[cpqDaPhyDrvMediaType.{#SNMPINDEX}]</key>
+                            <delay>1h</delay>
+                            <history>2w</history>
+                            <trends>0d</trends>
+                            <units>B</units>
+                            <description>MIB: CPQIDA-MIB&#13;
 Physical Drive Size in MB.&#13;
 This is the size of the physical drive in megabytes.&#13;
 This value is calculated using the value 1,048,576 (2^20) as a megabyte.&#13;
@@ -544,1621 +1351,2245 @@ Drive manufacturers sometimes use the number 1,000,000 as a megabyte when giving
 from the advertised size of a drive. This field is only applicable for controllers which support SCSI drives,&#13;
 and therefore is not supported by the IDA or IDA-2 controllers. The field will contain 0xFFFFFFFF if the drive capacity cannot be calculated&#13;
 or if the controller does not support SCSI drives.</description>
-                     <applications>
-                        <application>
-                           <name>Physical disks</name>
-                        </application>
-                     </applications>
-                     <preprocessing>
-                        <step>
-                           <type>MULTIPLIER</type>
-                           <params>1048576</params>
-                        </step>
-                     </preprocessing>
-                  </item_prototype>
-                  <item_prototype>
-                     <name>{#DISK_LOCATION}: Physical disk S.M.A.R.T. status</name>
-                     <type>SNMPV2</type>
-                     <snmp_community>{$SNMP_COMMUNITY}</snmp_community>
-                     <snmp_oid>1.3.6.1.4.1.232.3.2.5.1.1.57.{#SNMPINDEX}</snmp_oid>
-                     <key>system.hw.physicaldisk.smart_status[cpqDaPhyDrvSmartStatus.{#SNMPINDEX}]</key>
-                     <delay>3m</delay>
-                     <trends>0d</trends>
-                     <description>MIB: CPQIDA-MIB&#13;
+                            <applications>
+                                <application>
+                                    <name>Physical Disks</name>
+                                </application>
+                            </applications>
+                            <preprocessing>
+                                <step>
+                                    <type>MULTIPLIER</type>
+                                    <params>1048576</params>
+                                </step>
+                            </preprocessing>
+                        </item_prototype>
+                        <item_prototype>
+                            <name>{#DISK_LOCATION}: Drive S.M.A.R.T. status</name>
+                            <type>SNMP_AGENT</type>
+                            <snmp_oid>1.3.6.1.4.1.232.3.2.5.1.1.57.{#SNMPINDEX}</snmp_oid>
+                            <key>system.hw.physicaldisk.smart_status[cpqDaPhyDrvSmartStatus.{#SNMPINDEX}]</key>
+                            <delay>3m</delay>
+                            <history>30d</history>
+                            <trends>0d</trends>
+                            <description>MIB: CPQIDA-MIB&#13;
 Physical Drive S.M.A.R.T Status.The following values are defined:&#13;
 other(1)  The agent is unable to determine if the status of S.M.A.R.T  predictive failure monitoring for this drive.&#13;
 ok(2)  Indicates the drive is functioning properly.&#13;
 replaceDrive(3)  Indicates that the drive has a S.M.A.R.T predictive failure  error and should be replaced.</description>
-                     <applications>
-                        <application>
-                           <name>Physical disks</name>
-                        </application>
-                     </applications>
-                     <valuemap>
-                        <name>CPQIDA-MIB::cpqDaPhyDrvSmartStatus</name>
-                     </valuemap>
-                     <trigger_prototypes>
-                        <trigger_prototype>
-                           <expression>{count(#1,{$DISK_SMART_FAIL_STATUS:"replaceDrive"},eq)}=1 or {count(#1,{$DISK_SMART_FAIL_STATUS:"replaceDriveSSDWearOut"},eq)}=1</expression>
-                           <name>{#DISK_LOCATION}: Physical disk S.M.A.R.T. failed</name>
-                           <opdata>Current state: {ITEM.LASTVALUE1}</opdata>
-                           <priority>HIGH</priority>
-                           <description>Disk probably requires replacement.</description>
-                           <dependencies>
-                              <dependency>
-                                 <name>{#DISK_LOCATION}: Physical disk failed</name>
-                                 <expression>{Template Server HP iLO SNMPv2:system.hw.physicaldisk.status[cpqDaPhyDrvStatus.{#SNMPINDEX}].count(#1,{$DISK_FAIL_STATUS},eq)}=1</expression>
-                              </dependency>
-                           </dependencies>
-                        </trigger_prototype>
-                     </trigger_prototypes>
-                  </item_prototype>
-                  <item_prototype>
-                     <name>{#DISK_LOCATION}: Physical disk status</name>
-                     <type>SNMPV2</type>
-                     <snmp_community>{$SNMP_COMMUNITY}</snmp_community>
-                     <snmp_oid>1.3.6.1.4.1.232.3.2.5.1.1.6.{#SNMPINDEX}</snmp_oid>
-                     <key>system.hw.physicaldisk.status[cpqDaPhyDrvStatus.{#SNMPINDEX}]</key>
-                     <delay>3m</delay>
-                     <trends>0d</trends>
-                     <description>MIB: CPQIDA-MIB&#13;
-Physical Drive Status. This shows the status of the physical drive. The following values are valid for the physical drive status:&#13;
-other (1)  Indicates that the instrument agent does not recognize  the drive.&#13;
-You may need to upgrade your instrument agent  and/or driver software.&#13;
-ok (2)  Indicates the drive is functioning properly.&#13;
-failed (3)  Indicates that the drive is no longer operating and  should be replaced.&#13;
-predictiveFailure(4)  Indicates that the drive has a predictive failure error and  should be replaced.</description>
-                     <applications>
-                        <application>
-                           <name>Physical disks</name>
-                        </application>
-                     </applications>
-                     <valuemap>
-                        <name>CPQIDA-MIB::cpqDaPhyDrvStatus</name>
-                     </valuemap>
-                     <trigger_prototypes>
-                        <trigger_prototype>
-                           <expression>{count(#1,{$DISK_FAIL_STATUS},eq)}=1</expression>
-                           <name>{#DISK_LOCATION}: Physical disk failed</name>
-                           <opdata>Current status: {ITEM.LASTVALUE1}</opdata>
-                           <priority>HIGH</priority>
-                           <description>Please check physical disk for warnings or errors</description>
-                        </trigger_prototype>
-                        <trigger_prototype>
-                           <expression>{count(#1,{$DISK_WARN_STATUS},eq)}=1</expression>
-                           <name>{#DISK_LOCATION}: Physical disk is in warning state</name>
-                           <opdata>Current state: {ITEM.LASTVALUE1}</opdata>
-                           <priority>WARNING</priority>
-                           <description>Please check physical disk for warnings or errors</description>
-                           <dependencies>
-                              <dependency>
-                                 <name>{#DISK_LOCATION}: Physical disk failed</name>
-                                 <expression>{Template Server HP iLO SNMPv2:system.hw.physicaldisk.status[cpqDaPhyDrvStatus.{#SNMPINDEX}].count(#1,{$DISK_FAIL_STATUS},eq)}=1</expression>
-                              </dependency>
-                           </dependencies>
-                        </trigger_prototype>
-                     </trigger_prototypes>
-                  </item_prototype>
-               </item_prototypes>
-            </discovery_rule>
-            <discovery_rule>
-               <name>PSU Discovery</name>
-               <type>SNMPV2</type>
-               <snmp_community>{$SNMP_COMMUNITY}</snmp_community>
-               <snmp_oid>discovery[{#SNMPVALUE},1.3.6.1.4.1.232.6.2.9.3.1.5,{#CHASSIS_NUM},1.3.6.1.4.1.232.6.2.9.3.1.1,{#BAY_NUM},1.3.6.1.4.1.232.6.2.9.3.1.2]</snmp_oid>
-               <key>psu.discovery</key>
-               <delay>1h</delay>
-               <description>CPQHLTH-MIB::cpqHeFltTolPowerSupplyStatus</description>
-               <item_prototypes>
-                  <item_prototype>
-                     <name>Chassis {#CHASSIS_NUM}, bay {#BAY_NUM}: Power supply status</name>
-                     <type>SNMPV2</type>
-                     <snmp_community>{$SNMP_COMMUNITY}</snmp_community>
-                     <snmp_oid>1.3.6.1.4.1.232.6.2.9.3.1.4.{#SNMPINDEX}</snmp_oid>
-                     <key>sensor.psu.status[cpqHeFltTolPowerSupplyCondition.{#SNMPINDEX}]</key>
-                     <delay>3m</delay>
-                     <history>2w</history>
-                     <trends>0d</trends>
-                     <description>MIB: CPQHLTH-MIB&#13;
+                            <applications>
+                                <application>
+                                    <name>Physical Disks</name>
+                                </application>
+                            </applications>
+                            <valuemap>
+                                <name>CPQIDA-MIB::cpqDaPhyDrvSmartStatus</name>
+                            </valuemap>
+                            <trigger_prototypes>
+                                <trigger_prototype>
+                                    <expression>{last()}=3</expression>
+                                    <recovery_mode>RECOVERY_EXPRESSION</recovery_mode>
+                                    <recovery_expression>{last()}&lt;&gt;3</recovery_expression>
+                                    <name>{#DISK_LOCATION}: Physical disk S.M.A.R.T. failed</name>
+                                    <priority>HIGH</priority>
+                                    <description>Last value: {ITEM.LASTVALUE1}.&#13;
+Disk probably requires replacement.</description>
+                                </trigger_prototype>
+                                <trigger_prototype>
+                                    <expression>{last()}=4</expression>
+                                    <recovery_mode>RECOVERY_EXPRESSION</recovery_mode>
+                                    <recovery_expression>{last()}&lt;&gt;4</recovery_expression>
+                                    <name>{#DISK_LOCATION}: Physical disk S.M.A.R.T. failed ssd</name>
+                                    <priority>HIGH</priority>
+                                    <description>Replace the ssd disk immediately</description>
+                                </trigger_prototype>
+                            </trigger_prototypes>
+                        </item_prototype>
+                        <item_prototype>
+                            <name>{#DISK_LOCATION}: Drive wear status</name>
+                            <type>SNMP_AGENT</type>
+                            <snmp_oid>1.3.6.1.4.1.232.3.2.5.1.1.73.{#SNMPINDEX}</snmp_oid>
+                            <key>system.hw.physicaldisk.ssdWear[cpqDaPhyDrvSSDWearStatus.{#SNMPINDEX}]</key>
+                            <delay>1d</delay>
+                            <history>2w</history>
+                            <trends>0d</trends>
+                            <description>CPQIDA-MIB::cpqDaPhyDrvSSDWearStatus&#13;
+&#13;
+Drive Array Physical Drive Solid State Disk Wear Status. This shows the wear status of the solid state physical drive. The following values are valid for the physical drive solid state wear status: Other (1) The instrument agent is unable to determine the physical drive?s solid state disk wear status. This value would be used for non SSD drives or SSD drives that do not support wear reporting. Ok (2) Indicates the solid state disk is not in any imminent danger of wear out. Fifty Six Day Threshold Passed (3) Indicates that based upon the current workload, the solid state disk will reach the maximum usage limit for writes (wear out) within fifty-six days. You should modify your write workload or begin preparing to replace your SSD drive. Five Percent Threshold Passed (4) Indicates that the solid state disk has passed the five percent threshold and is at or below five percent of reaching the maximum usage limit for writes (wear out). You should begin to prepare to replace your SSD drive. Two Percent Threshold Passed (5) Indicates that the solid state disk has passed the two percent threshold and is at or below two percent of reaching the maximum usage limit for writes (wear out). You should begin to prepare to replace your SSD drive. SSD Wear Out(6) Indicates that a solid state drive is approaching the maximum usage limit for writes (wear out) and should be replaced as soon as possible</description>
+                            <applications>
+                                <application>
+                                    <name>Physical Disks</name>
+                                </application>
+                            </applications>
+                            <valuemap>
+                                <name>CPQIDA-MIB::cpqDaPhyDrvSSDWearStatus</name>
+                            </valuemap>
+                            <trigger_prototypes>
+                                <trigger_prototype>
+                                    <expression>{last()}=6</expression>
+                                    <recovery_mode>RECOVERY_EXPRESSION</recovery_mode>
+                                    <recovery_expression>{last()}&lt;&gt;6</recovery_expression>
+                                    <name>{#DISK_LOCATION}: Disk ssd is worn out, replace immediately</name>
+                                    <priority>DISASTER</priority>
+                                </trigger_prototype>
+                                <trigger_prototype>
+                                    <expression>{last()}=5</expression>
+                                    <recovery_mode>RECOVERY_EXPRESSION</recovery_mode>
+                                    <recovery_expression>{last()}&lt;&gt;5</recovery_expression>
+                                    <name>{#DISK_LOCATION}: Disk ssd wear status has 2% remaining</name>
+                                    <priority>HIGH</priority>
+                                    <manual_close>YES</manual_close>
+                                </trigger_prototype>
+                                <trigger_prototype>
+                                    <expression>{last()}=4</expression>
+                                    <recovery_mode>RECOVERY_EXPRESSION</recovery_mode>
+                                    <recovery_expression>{last()}&lt;&gt;4</recovery_expression>
+                                    <name>{#DISK_LOCATION}: Disk ssd wear status has 5% remaining</name>
+                                    <priority>AVERAGE</priority>
+                                    <manual_close>YES</manual_close>
+                                </trigger_prototype>
+                                <trigger_prototype>
+                                    <expression>{last()}=3</expression>
+                                    <recovery_mode>RECOVERY_EXPRESSION</recovery_mode>
+                                    <recovery_expression>{last()}&lt;&gt;3</recovery_expression>
+                                    <name>{#DISK_LOCATION}: Disk ssd wear status has reached 56 days</name>
+                                    <priority>INFO</priority>
+                                    <manual_close>YES</manual_close>
+                                </trigger_prototype>
+                            </trigger_prototypes>
+                        </item_prototype>
+                        <item_prototype>
+                            <name>{#DISK_LOCATION}: Drive controller</name>
+                            <type>SNMP_AGENT</type>
+                            <snmp_oid>1.3.6.1.4.1.232.3.2.5.1.1.1.{#SNMPINDEX}</snmp_oid>
+                            <key>system.hw.physicaldisk.status[cpqDaPhyDrvCntlrIndex.{#SNMPINDEX}]</key>
+                            <delay>1d</delay>
+                            <description>Drive Array Physical Drive Controller Index. This index maps the physical drive back to the controller to which it is attached. The value of this index is the same as the one used under the controller group.</description>
+                            <applications>
+                                <application>
+                                    <name>Physical Disks</name>
+                                </application>
+                            </applications>
+                        </item_prototype>
+                        <item_prototype>
+                            <name>{#DISK_LOCATION}: Drive status</name>
+                            <type>SNMP_AGENT</type>
+                            <snmp_oid>1.3.6.1.4.1.232.3.2.5.1.1.6.{#SNMPINDEX}</snmp_oid>
+                            <key>system.hw.physicaldisk.status[cpqDaPhyDrvStatus.{#SNMPINDEX}]</key>
+                            <delay>2m</delay>
+                            <history>30d</history>
+                            <applications>
+                                <application>
+                                    <name>Physical Disks</name>
+                                </application>
+                            </applications>
+                            <valuemap>
+                                <name>CPQIDA-MIB::cpqDaPhyDrvStatus</name>
+                            </valuemap>
+                        </item_prototype>
+                        <item_prototype>
+                            <name>{#DISK_LOCATION}: Drive temperature threshold</name>
+                            <type>SNMP_AGENT</type>
+                            <snmp_oid>1.3.6.1.4.1.232.3.2.5.1.1.71.{#SNMPINDEX}</snmp_oid>
+                            <key>system.hw.physicaldisk.tempThld[cpqDaPhyDrvTemperatureThreshold.{#SNMPINDEX}]</key>
+                            <delay>1d</delay>
+                            <history>7d</history>
+                            <trends>0d</trends>
+                            <units>°C</units>
+                            <applications>
+                                <application>
+                                    <name>Physical Disks</name>
+                                </application>
+                            </applications>
+                        </item_prototype>
+                        <item_prototype>
+                            <name>{#DISK_LOCATION}: Drive temperature</name>
+                            <type>SNMP_AGENT</type>
+                            <snmp_oid>1.3.6.1.4.1.232.3.2.5.1.1.70.{#SNMPINDEX}</snmp_oid>
+                            <key>system.hw.physicaldisk.temp[cpqDaPhyDrvCurrentTemperature.{#SNMPINDEX}]</key>
+                            <delay>3m</delay>
+                            <history>30d</history>
+                            <units>°C</units>
+                            <applications>
+                                <application>
+                                    <name>Physical Disks</name>
+                                </application>
+                            </applications>
+                        </item_prototype>
+                        <item_prototype>
+                            <name>{#DISK_LOCATION}: Drive type</name>
+                            <type>SNMP_AGENT</type>
+                            <snmp_oid>1.3.6.1.4.1.232.3.2.5.1.1.60.{#SNMPINDEX}</snmp_oid>
+                            <key>system.hw.physicaldisk.type[cpqDaPhyDrvType.{#SNMPINDEX}]</key>
+                            <delay>1d</delay>
+                            <history>2w</history>
+                            <trends>0d</trends>
+                            <description>CPQIDA-MIB::cpqDaPhyDrvType&#13;
+&#13;
+Physical Drive Type. The following values are defined: other(1) The agent is unable to determine the type for this drive. parallelScsi(2) The drive type is parallel SCSI. sata(3) The drive type is Serial ATA. sas(4) The drive type is Serial Attached SCSI.</description>
+                            <applications>
+                                <application>
+                                    <name>Physical Disks</name>
+                                </application>
+                            </applications>
+                            <valuemap>
+                                <name>CPQIDA-MIB::cpqDaPhyDrvType</name>
+                            </valuemap>
+                        </item_prototype>
+                    </item_prototypes>
+                </discovery_rule>
+                <discovery_rule>
+                    <name>PSU Discovery</name>
+                    <type>SNMP_AGENT</type>
+                    <snmp_oid>discovery[{#SNMPVALUE},1.3.6.1.4.1.232.6.2.9.3.1.5,{#CHASSIS_NUM},1.3.6.1.4.1.232.6.2.9.3.1.1,{#BAY_NUM},1.3.6.1.4.1.232.6.2.9.3.1.2]</snmp_oid>
+                    <key>psu.discovery</key>
+                    <delay>1h</delay>
+                    <description>CPQHLTH-MIB::cpqHeFltTolPowerSupplyStatus</description>
+                    <item_prototypes>
+                        <item_prototype>
+                            <name>System: Power Chassis {#CHASSIS_NUM}, Bay {#BAY_NUM} Condition Code</name>
+                            <type>SNMP_AGENT</type>
+                            <snmp_oid>1.3.6.1.4.1.232.6.2.9.3.1.18.{#SNMPINDEX}</snmp_oid>
+                            <key>sensor.psu.folTolErrorCondition[cpqHeFltTolPowerSupplyErrorCondition.{#SNMPINDEX}]</key>
+                            <delay>2m</delay>
+                            <history>2w</history>
+                            <trends>0d</trends>
+                            <description>CPQHLTH-MIB::cpqHeFltTolPowerSupplyErrorCondition&#13;
+&#13;
+noError(1), generalFailure(2), overvoltage(3), overcurrent(4), overtemperature(5), powerinputloss(6), fanfailure(7), vinhighwarning(8), vinlowwarning(9), vouthighwarning(10), voutlowwarning(11), inlettemphighwarning(12), iinternaltemphighwarning(13), vauxhighwarning(14), vauxlowwarning(15)</description>
+                            <applications>
+                                <application>
+                                    <name>Power Supply</name>
+                                </application>
+                            </applications>
+                            <valuemap>
+                                <name>CPQHLTH-MIB::cpqHeFltTolPowerSupplyErrorCondition</name>
+                            </valuemap>
+                            <trigger_prototypes>
+                                <trigger_prototype>
+                                    <expression>{last()}&lt;&gt;1</expression>
+                                    <recovery_mode>RECOVERY_EXPRESSION</recovery_mode>
+                                    <recovery_expression>{last()}=1</recovery_expression>
+                                    <name>Chassis {#CHASSIS_NUM}, Bay {#BAY_NUM}: Power supply has error code</name>
+                                    <priority>WARNING</priority>
+                                    <manual_close>YES</manual_close>
+                                </trigger_prototype>
+                            </trigger_prototypes>
+                        </item_prototype>
+                        <item_prototype>
+                            <name>System: Power Chassis {#CHASSIS_NUM}, Bay {#BAY_NUM} Hot Pluggable</name>
+                            <type>SNMP_AGENT</type>
+                            <snmp_oid>1.3.6.1.4.1.232.6.2.9.3.1.13.{#SNMPINDEX}</snmp_oid>
+                            <key>sensor.psu.folTolHotPlug[cpqHeFltTolPowerSupplyHotPlug.{#SNMPINDEX}]</key>
+                            <delay>1d</delay>
+                            <history>1w</history>
+                            <trends>0d</trends>
+                            <description>CPQHLTH-MIB::cpqHeFltTolPowerSupplyHotPlug&#13;
+&#13;
+This indicates if the power supply is capable of being removed and/or inserted while the system is in an operational state. If the value is hotPluggable(3), the power supply can be safely removed if and only if the cpqHeFltTolPowerSupplyRedundant field is in a redundant(3) state. This value will be one of the following: other(1) The state could not be determined. nonHotPluggable(2) The power supply is not hot plug capable. hotPluggable(3) The power supply is hot plug capable and can be removed if the system is operating in a redundant state. A power supply may be added to an empty power supply bay.</description>
+                            <applications>
+                                <application>
+                                    <name>Power Supply</name>
+                                </application>
+                            </applications>
+                            <valuemap>
+                                <name>CPQHLTH-MIB::cpqHeFltTolPowerSupplyHotPlug</name>
+                            </valuemap>
+                        </item_prototype>
+                        <item_prototype>
+                            <name>System: Power Chassis {#CHASSIS_NUM}, Bay {#BAY_NUM} Model</name>
+                            <type>SNMP_AGENT</type>
+                            <snmp_oid>1.3.6.1.4.1.232.6.2.9.3.1.10.{#SNMPINDEX}</snmp_oid>
+                            <key>sensor.psu.folTolModel[cpqHeFltTolPowerSupplyModel.{#SNMPINDEX}]</key>
+                            <delay>1d</delay>
+                            <history>1w</history>
+                            <trends>0</trends>
+                            <value_type>TEXT</value_type>
+                            <description>CPQHLTH-MIB::cpqHeFltTolPowerSupplyModel&#13;
+&#13;
+The power supply model name.</description>
+                            <applications>
+                                <application>
+                                    <name>Inventory</name>
+                                </application>
+                                <application>
+                                    <name>Power Supply</name>
+                                </application>
+                            </applications>
+                        </item_prototype>
+                        <item_prototype>
+                            <name>System: Power Chassis {#CHASSIS_NUM}, Bay {#BAY_NUM} Present</name>
+                            <type>SNMP_AGENT</type>
+                            <snmp_oid>1.3.6.1.4.1.232.6.2.9.3.1.3.{#SNMPINDEX}</snmp_oid>
+                            <key>sensor.psu.folTolPresent[cpqHeFltTolPowerSupplyPresent.{#SNMPINDEX}]</key>
+                            <delay>2m</delay>
+                            <history>1w</history>
+                            <trends>0d</trends>
+                            <description>CPQHLTH-MIB::cpqHeFltTolPowerSupplyPresent&#13;
+&#13;
+Indicates whether the power supply is present in the chassis.</description>
+                            <applications>
+                                <application>
+                                    <name>Power Supply</name>
+                                </application>
+                            </applications>
+                            <valuemap>
+                                <name>CPQHLTH-MIB::cpqHeFltTolPowerSupplyPresent</name>
+                            </valuemap>
+                        </item_prototype>
+                        <item_prototype>
+                            <name>System: Power Chassis {#CHASSIS_NUM}, Bay {#BAY_NUM} Redundant</name>
+                            <type>SNMP_AGENT</type>
+                            <snmp_oid>1.3.6.1.4.1.232.6.2.9.3.1.9.{#SNMPINDEX}</snmp_oid>
+                            <key>sensor.psu.folTolRedundant[cpqHeFltTolPowerSupplyRedundant.{#SNMPINDEX}]</key>
+                            <delay>2m</delay>
+                            <history>1w</history>
+                            <trends>0d</trends>
+                            <description>CPQHLTH-MIB::cpqHeFltTolPowerSupplyRedundant&#13;
+&#13;
+The redundancy state of the power supply. This value will be one of the following: other(1) The redundancy state could not be determined. notRedundant(2) The power supply is not operating in a redundant state. redundant(3) The power supply is operating in a redundant state.</description>
+                            <applications>
+                                <application>
+                                    <name>Power Supply</name>
+                                </application>
+                            </applications>
+                            <valuemap>
+                                <name>CPQHLTH-MIB::cpqHeFltTolPowerSupplyRedundant</name>
+                            </valuemap>
+                        </item_prototype>
+                        <item_prototype>
+                            <name>System: Power Chassis {#CHASSIS_NUM}, Bay {#BAY_NUM} Serial Number</name>
+                            <type>SNMP_AGENT</type>
+                            <snmp_oid>1.3.6.1.4.1.232.6.2.9.3.1.11.{#SNMPINDEX}</snmp_oid>
+                            <key>sensor.psu.folTolSerial[cpqHeFltTolPowerSupplySerialNumber.{#SNMPINDEX}]</key>
+                            <delay>1d</delay>
+                            <history>1w</history>
+                            <trends>0</trends>
+                            <value_type>TEXT</value_type>
+                            <description>CPQHLTH-MIB::cpqHeFltTolPowerSupplySerialNumber&#13;
+&#13;
+The power supply serial number.</description>
+                            <applications>
+                                <application>
+                                    <name>Inventory</name>
+                                </application>
+                                <application>
+                                    <name>Power Supply</name>
+                                </application>
+                            </applications>
+                        </item_prototype>
+                        <item_prototype>
+                            <name>System: Power Chassis {#CHASSIS_NUM}, Bay {#BAY_NUM} Model Spare</name>
+                            <type>SNMP_AGENT</type>
+                            <snmp_oid>1.3.6.1.4.1.232.6.2.9.3.1.16.{#SNMPINDEX}</snmp_oid>
+                            <key>sensor.psu.folTolSparePart[cpqHeFltTolPowerSupplySparePartNum.{#SNMPINDEX}]</key>
+                            <delay>1d</delay>
+                            <history>1w</history>
+                            <trends>0</trends>
+                            <value_type>TEXT</value_type>
+                            <description>CPQHLTH-MIB::cpqHeFltTolPowerSupplySparePartNum&#13;
+&#13;
+The power supply part number or spare part number.</description>
+                            <applications>
+                                <application>
+                                    <name>Inventory</name>
+                                </application>
+                                <application>
+                                    <name>Power Supply</name>
+                                </application>
+                            </applications>
+                        </item_prototype>
+                        <item_prototype>
+                            <name>System: Power Chassis {#CHASSIS_NUM}, Bay {#BAY_NUM} Status</name>
+                            <type>SNMP_AGENT</type>
+                            <snmp_oid>1.3.6.1.4.1.232.6.2.9.3.1.5.{#SNMPINDEX}</snmp_oid>
+                            <key>sensor.psu.folTolStatus[cpqHeFltTolPowerSupplyStatus.{#SNMPINDEX}]</key>
+                            <delay>2m</delay>
+                            <history>1w</history>
+                            <trends>0d</trends>
+                            <description>CPQHLTH-MIB::cpqHeFltTolPowerSupplyStatus&#13;
+&#13;
+noError(1), generalFailure(2), bistFailure(3), fanFailure(4), tempFailure(5), interlockOpen(6), epromFailed(7), vrefFailed(8), dacFailed(9), ramTestFailed(10), voltageChannelFailed(11), orringdiodeFailed(12), brownOut(13), giveupOnStartup(14), nvramInvalid(15), calibrationTableInvalid(16)</description>
+                            <applications>
+                                <application>
+                                    <name>Power Supply</name>
+                                </application>
+                            </applications>
+                            <valuemap>
+                                <name>CPQHLTH-MIB::cpqHeFltTolPowerSupplyStatus</name>
+                            </valuemap>
+                        </item_prototype>
+                        <item_prototype>
+                            <name>System: Power Chassis {#CHASSIS_NUM}, Bay {#BAY_NUM} Condition</name>
+                            <type>SNMP_AGENT</type>
+                            <snmp_oid>1.3.6.1.4.1.232.6.2.9.3.1.4.{#SNMPINDEX}</snmp_oid>
+                            <key>sensor.psu.status[cpqHeFltTolPowerSupplyCondition.{#SNMPINDEX}]</key>
+                            <delay>2m</delay>
+                            <history>1w</history>
+                            <trends>0d</trends>
+                            <description>MIB: CPQHLTH-MIB&#13;
+&#13;
 The condition of the power supply. This value will be one of the following:&#13;
 other(1)  The status could not be determined or not present.&#13;
 ok(2)  The power supply is operating normally.&#13;
 degraded(3)  A temperature sensor, fan or other power supply component is  outside of normal operating range.&#13;
 failed(4)  A power supply component detects a condition that could  permanently damage the system.</description>
-                     <applications>
-                        <application>
-                           <name>Power supply</name>
-                        </application>
-                     </applications>
-                     <valuemap>
-                        <name>CPQSINFO-MIB::status</name>
-                     </valuemap>
-                     <trigger_prototypes>
-                        <trigger_prototype>
-                           <expression>{count(#1,{$PSU_CRIT_STATUS},eq)}=1</expression>
-                           <name>Chassis {#CHASSIS_NUM}, bay {#BAY_NUM}: Power supply is in critical state</name>
-                           <opdata>Current state: {ITEM.LASTVALUE1}</opdata>
-                           <priority>AVERAGE</priority>
-                           <description>Please check the power supply unit for errors</description>
-                        </trigger_prototype>
-                        <trigger_prototype>
-                           <expression>{count(#1,{$PSU_WARN_STATUS},eq)}=1</expression>
-                           <name>Chassis {#CHASSIS_NUM}, bay {#BAY_NUM}: Power supply is in warning state</name>
-                           <opdata>Current state: {ITEM.LASTVALUE1}</opdata>
-                           <priority>WARNING</priority>
-                           <description>Please check the power supply unit for errors</description>
-                           <dependencies>
-                              <dependency>
-                                 <name>Chassis {#CHASSIS_NUM}, bay {#BAY_NUM}: Power supply is in critical state</name>
-                                 <expression>{Template Server HP iLO SNMPv2:sensor.psu.status[cpqHeFltTolPowerSupplyCondition.{#SNMPINDEX}].count(#1,{$PSU_CRIT_STATUS},eq)}=1</expression>
-                              </dependency>
-                           </dependencies>
-                        </trigger_prototype>
-                     </trigger_prototypes>
-                  </item_prototype>
-               </item_prototypes>
-            </discovery_rule>
-            <discovery_rule>
-               <name>Temperature Discovery</name>
-               <type>SNMPV2</type>
-               <snmp_community>{$SNMP_COMMUNITY}</snmp_community>
-               <snmp_oid>discovery[{#SNMPVALUE},1.3.6.1.4.1.232.6.2.6.8.1.1,{#SENSOR_LOCALE},1.3.6.1.4.1.232.6.2.6.8.1.3]</snmp_oid>
-               <key>tempDescr.discovery</key>
-               <delay>1h</delay>
-               <filter>
-                  <evaltype>AND_OR</evaltype>
-                  <conditions>
-                     <condition>
-                        <macro>{#SENSOR_LOCALE}</macro>
-                        <value>(4|8|9|12|13)</value>
-                        <formulaid>A</formulaid>
-                     </condition>
-                  </conditions>
-               </filter>
-               <description>Scanning table of Temperature Sensor Entries: CPQHLTH-MIB::cpqHeTemperatureTable</description>
-               <item_prototypes>
-                  <item_prototype>
-                     <name>{#SNMPINDEX}: Temperature sensor location</name>
-                     <type>SNMPV2</type>
-                     <snmp_community>{$SNMP_COMMUNITY}</snmp_community>
-                     <snmp_oid>1.3.6.1.4.1.232.6.2.6.8.1.3.{#SNMPINDEX}</snmp_oid>
-                     <key>sensor.temp.locale[cpqHeTemperatureLocale.{#SNMPINDEX}]</key>
-                     <delay>1h</delay>
-                     <history>1w</history>
-                     <trends>0d</trends>
-                     <description>MIB: CPQHLTH-MIB&#13;
+                            <applications>
+                                <application>
+                                    <name>Power Supply</name>
+                                </application>
+                            </applications>
+                            <valuemap>
+                                <name>CPQHLTH-MIB::cpqHeFltTolPowerSupplyCondition</name>
+                            </valuemap>
+                            <trigger_prototypes>
+                                <trigger_prototype>
+                                    <expression>{last()}=4</expression>
+                                    <recovery_mode>RECOVERY_EXPRESSION</recovery_mode>
+                                    <recovery_expression>{last()}&lt;&gt;4</recovery_expression>
+                                    <name>Chassis {#CHASSIS_NUM}, Bay {#BAY_NUM}: Power supply is in critical state</name>
+                                    <priority>HIGH</priority>
+                                    <description>Last value: {ITEM.LASTVALUE1}.&#13;
+Please check the power supply unit for errors</description>
+                                </trigger_prototype>
+                                <trigger_prototype>
+                                    <expression>{last()}=3</expression>
+                                    <recovery_mode>RECOVERY_EXPRESSION</recovery_mode>
+                                    <recovery_expression>{last()}&lt;&gt;3</recovery_expression>
+                                    <name>Chassis {#CHASSIS_NUM}, Bay {#BAY_NUM}: Power supply is in degraded state</name>
+                                    <priority>WARNING</priority>
+                                </trigger_prototype>
+                            </trigger_prototypes>
+                        </item_prototype>
+                    </item_prototypes>
+                </discovery_rule>
+                <discovery_rule>
+                    <name>Temperature Discovery</name>
+                    <type>SNMP_AGENT</type>
+                    <snmp_oid>discovery[{#SNMPVALUE},1.3.6.1.4.1.232.6.2.6.8.1.1,{#SENSOR_LOCALE},1.3.6.1.4.1.232.6.2.6.8.1.3,{#SENSOR_THRESHOLD},1.3.6.1.4.1.232.6.2.6.8.1.5]</snmp_oid>
+                    <key>tempDescr.discovery</key>
+                    <delay>1h</delay>
+                    <description>Scanning table of Temperature Sensor Entries: CPQHLTH-MIB::cpqHeTemperatureTable</description>
+                    <item_prototypes>
+                        <item_prototype>
+                            <name>{#SNMPINDEX}: Temperature Locale</name>
+                            <type>SNMP_AGENT</type>
+                            <snmp_oid>1.3.6.1.4.1.232.6.2.6.8.1.3.{#SNMPINDEX}</snmp_oid>
+                            <key>sensor.temp.locale[cpqHeTemperatureLocale.{#SNMPINDEX}]</key>
+                            <delay>1d</delay>
+                            <history>7d</history>
+                            <trends>0</trends>
+                            <description>MIB: CPQHLTH-MIB&#13;
 This specifies the location of the temperature sensor present in the system.</description>
-                     <applications>
-                        <application>
-                           <name>Temperature</name>
-                        </application>
-                     </applications>
-                     <valuemap>
-                        <name>CPQHLTH-MIB::cpqHeTemperatureLocale</name>
-                     </valuemap>
-                  </item_prototype>
-                  <item_prototype>
-                     <name>{#SNMPINDEX}: Temperature</name>
-                     <type>SNMPV2</type>
-                     <snmp_community>{$SNMP_COMMUNITY}</snmp_community>
-                     <snmp_oid>1.3.6.1.4.1.232.6.2.6.8.1.4.{#SNMPINDEX}</snmp_oid>
-                     <key>sensor.temp.value[cpqHeTemperatureCelsius.{#SNMPINDEX}]</key>
-                     <delay>6m</delay>
-                     <value_type>FLOAT</value_type>
-                     <units>°C</units>
-                     <description>MIB: CPQHLTH-MIB&#13;
+                            <applications>
+                                <application>
+                                    <name>Temperature</name>
+                                </application>
+                            </applications>
+                            <valuemap>
+                                <name>CPQHLTH-MIB::cpqHeTemperatureLocale</name>
+                            </valuemap>
+                        </item_prototype>
+                        <item_prototype>
+                            <name>{#SNMPINDEX}: Temperature Threshold</name>
+                            <type>SNMP_AGENT</type>
+                            <snmp_oid>1.3.6.1.4.1.232.6.2.6.8.1.5.{#SNMPINDEX}</snmp_oid>
+                            <key>sensor.temp.threshold[cpqHeTemperatureThreshold.{#SNMPINDEX}]</key>
+                            <delay>1d</delay>
+                            <history>7d</history>
+                            <trends>0</trends>
+                            <value_type>FLOAT</value_type>
+                            <units>°C</units>
+                            <description>Temp Sensor Critical Threshold Value</description>
+                            <applications>
+                                <application>
+                                    <name>Temperature</name>
+                                </application>
+                            </applications>
+                        </item_prototype>
+                        <item_prototype>
+                            <name>{#SNMPINDEX}: Temperature Reading</name>
+                            <type>SNMP_AGENT</type>
+                            <snmp_oid>1.3.6.1.4.1.232.6.2.6.8.1.4.{#SNMPINDEX}</snmp_oid>
+                            <key>sensor.temp.value[cpqHeTemperatureCelsius.{#SNMPINDEX}]</key>
+                            <delay>180</delay>
+                            <value_type>FLOAT</value_type>
+                            <units>°C</units>
+                            <description>MIB: CPQHLTH-MIB&#13;
 Temperature readings of testpoint: {#SNMPINDEX}</description>
-                     <applications>
-                        <application>
-                           <name>Temperature</name>
-                        </application>
-                     </applications>
-                     <trigger_prototypes>
+                            <applications>
+                                <application>
+                                    <name>Temperature</name>
+                                </application>
+                            </applications>
+                        </item_prototype>
+                    </item_prototypes>
+                    <trigger_prototypes>
                         <trigger_prototype>
-                           <expression>{avg(5m)}&gt;{$TEMP_WARN:"{#SNMPINDEX}"}</expression>
-                           <recovery_mode>RECOVERY_EXPRESSION</recovery_mode>
-                           <recovery_expression>{max(5m)}&lt;{$TEMP_WARN:"{#SNMPINDEX}"}-3</recovery_expression>
-                           <name>{#SNMPINDEX}: Temperature is above warning threshold: &gt;{$TEMP_WARN:"{#SNMPINDEX}"}</name>
-                           <opdata>Current value: {ITEM.LASTVALUE1}</opdata>
-                           <priority>WARNING</priority>
-                           <description>This trigger uses temperature sensor values as well as temperature sensor status if available</description>
-                           <dependencies>
-                              <dependency>
-                                 <name>{#SNMPINDEX}: Temperature is above critical threshold: &gt;{$TEMP_CRIT:"{#SNMPINDEX}"}</name>
-                                 <expression>{Template Server HP iLO SNMPv2:sensor.temp.value[cpqHeTemperatureCelsius.{#SNMPINDEX}].avg(5m)}&gt;{$TEMP_CRIT:"{#SNMPINDEX}"}</expression>
-                                 <recovery_expression>{Template Server HP iLO SNMPv2:sensor.temp.value[cpqHeTemperatureCelsius.{#SNMPINDEX}].max(5m)}&lt;{$TEMP_CRIT:"{#SNMPINDEX}"}-3</recovery_expression>
-                              </dependency>
-                           </dependencies>
+                            <expression>{Template Server HP iLO SNMPv2:sensor.temp.threshold[cpqHeTemperatureThreshold.{#SNMPINDEX}].last()}&lt;&gt;0 and&#13;
+{Template Server HP iLO SNMPv2:sensor.temp.value[cpqHeTemperatureCelsius.{#SNMPINDEX}].last(5m)}&gt;{Template Server HP iLO SNMPv2:sensor.temp.threshold[cpqHeTemperatureThreshold.{#SNMPINDEX}].last(5m)}</expression>
+                            <recovery_mode>RECOVERY_EXPRESSION</recovery_mode>
+                            <recovery_expression>{Template Server HP iLO SNMPv2:sensor.temp.threshold[cpqHeTemperatureThreshold.{#SNMPINDEX}].last()}&lt;&gt;0 and&#13;
+{Template Server HP iLO SNMPv2:sensor.temp.value[cpqHeTemperatureCelsius.{#SNMPINDEX}].last(5m)}&lt;={Template Server HP iLO SNMPv2:sensor.temp.threshold[cpqHeTemperatureThreshold.{#SNMPINDEX}].last(5m)}-3</recovery_expression>
+                            <name>Temperature is above mfg threshold: &quot;{#SENSOR_THRESHOLD}°C&quot;}</name>
+                            <priority>HIGH</priority>
+                            <description>Last value: {ITEM.LASTVALUE1}.&#13;
+This trigger uses temperature sensor values as well as temperature sensor status if available</description>
                         </trigger_prototype>
                         <trigger_prototype>
-                           <expression>{avg(5m)}&gt;{$TEMP_CRIT:"{#SNMPINDEX}"}</expression>
-                           <recovery_mode>RECOVERY_EXPRESSION</recovery_mode>
-                           <recovery_expression>{max(5m)}&lt;{$TEMP_CRIT:"{#SNMPINDEX}"}-3</recovery_expression>
-                           <name>{#SNMPINDEX}: Temperature is above critical threshold: &gt;{$TEMP_CRIT:"{#SNMPINDEX}"}</name>
-                           <opdata>Current value: {ITEM.LASTVALUE1}</opdata>
-                           <priority>HIGH</priority>
-                           <description>This trigger uses temperature sensor values as well as temperature sensor status if available</description>
+                            <expression>{Template Server HP iLO SNMPv2:sensor.temp.threshold[cpqHeTemperatureThreshold.{#SNMPINDEX}].last()}&lt;&gt;0 &#13;
+and&#13;
+{Template Server HP iLO SNMPv2:sensor.temp.value[cpqHeTemperatureCelsius.{#SNMPINDEX}].last(5m)}&gt;={Template Server HP iLO SNMPv2:sensor.temp.threshold[cpqHeTemperatureThreshold.{#SNMPINDEX}].last(5m)}-{$TEMP_WARN}</expression>
+                            <recovery_mode>RECOVERY_EXPRESSION</recovery_mode>
+                            <recovery_expression>{Template Server HP iLO SNMPv2:sensor.temp.threshold[cpqHeTemperatureThreshold.{#SNMPINDEX}].last()}&lt;&gt;0 &#13;
+and&#13;
+{Template Server HP iLO SNMPv2:sensor.temp.value[cpqHeTemperatureCelsius.{#SNMPINDEX}].last(5m)}+{$TEMP_WARN} &lt;{Template Server HP iLO SNMPv2:sensor.temp.threshold[cpqHeTemperatureThreshold.{#SNMPINDEX}].last(5m)}</recovery_expression>
+                            <name>Temperature is nearing mfg threshold: {#SENSOR_THRESHOLD}°C&quot;}</name>
+                            <priority>WARNING</priority>
                         </trigger_prototype>
-                        <trigger_prototype>
-                           <expression>{avg(5m)}&lt;{$TEMP_CRIT_LOW:"{#SNMPINDEX}"}</expression>
-                           <recovery_mode>RECOVERY_EXPRESSION</recovery_mode>
-                           <recovery_expression>{min(5m)}&gt;{$TEMP_CRIT_LOW:"{#SNMPINDEX}"}+3</recovery_expression>
-                           <name>{#SNMPINDEX}: Temperature is too low: &lt;{$TEMP_CRIT_LOW:"{#SNMPINDEX}"}</name>
-                           <opdata>Current value: {ITEM.LASTVALUE1}</opdata>
-                           <priority>AVERAGE</priority>
-                        </trigger_prototype>
-                     </trigger_prototypes>
-                  </item_prototype>
-               </item_prototypes>
-            </discovery_rule>
-            <discovery_rule>
-               <name>Temperature Discovery Ambient</name>
-               <type>SNMPV2</type>
-               <snmp_community>{$SNMP_COMMUNITY}</snmp_community>
-               <snmp_oid>discovery[{#SNMPVALUE},1.3.6.1.4.1.232.6.2.6.8.1.1,{#SENSOR_LOCALE},1.3.6.1.4.1.232.6.2.6.8.1.3]</snmp_oid>
-               <key>tempDescr.discovery.ambient</key>
-               <delay>1h</delay>
-               <filter>
-                  <evaltype>AND_OR</evaltype>
-                  <conditions>
-                     <condition>
-                        <macro>{#SNMPINDEX}</macro>
-                        <value>0\.1</value>
-                        <formulaid>B</formulaid>
-                     </condition>
-                     <condition>
-                        <macro>{#SENSOR_LOCALE}</macro>
-                        <value>11</value>
-                        <formulaid>A</formulaid>
-                     </condition>
-                  </conditions>
-               </filter>
-               <description>Scanning table of Temperature Sensor Entries: CPQHLTH-MIB::cpqHeTemperatureTable with ambient(11) and 0.1 index filter</description>
-               <item_prototypes>
-                  <item_prototype>
-                     <name>Ambient: Temperature</name>
-                     <type>SNMPV2</type>
-                     <snmp_community>{$SNMP_COMMUNITY}</snmp_community>
-                     <snmp_oid>1.3.6.1.4.1.232.6.2.6.8.1.4.{#SNMPINDEX}</snmp_oid>
-                     <key>sensor.temp.value[cpqHeTemperatureCelsius.Ambient.{#SNMPINDEX}]</key>
-                     <delay>3m</delay>
-                     <value_type>FLOAT</value_type>
-                     <units>°C</units>
-                     <description>MIB: CPQHLTH-MIB&#13;
-Temperature readings of testpoint: Ambient</description>
-                     <applications>
-                        <application>
-                           <name>Temperature</name>
-                        </application>
-                     </applications>
-                     <trigger_prototypes>
-                        <trigger_prototype>
-                           <expression>{avg(5m)}&gt;{$TEMP_WARN:"Ambient"}</expression>
-                           <recovery_mode>RECOVERY_EXPRESSION</recovery_mode>
-                           <recovery_expression>{max(5m)}&lt;{$TEMP_WARN:"Ambient"}-3</recovery_expression>
-                           <name>Ambient: Temperature is above warning threshold: &gt;{$TEMP_WARN:"Ambient"}</name>
-                           <opdata>Current value: {ITEM.LASTVALUE1}</opdata>
-                           <priority>WARNING</priority>
-                           <description>This trigger uses temperature sensor values as well as temperature sensor status if available</description>
-                           <dependencies>
-                              <dependency>
-                                 <name>Ambient: Temperature is above critical threshold: &gt;{$TEMP_CRIT:"Ambient"}</name>
-                                 <expression>{Template Server HP iLO SNMPv2:sensor.temp.value[cpqHeTemperatureCelsius.Ambient.{#SNMPINDEX}].avg(5m)}&gt;{$TEMP_CRIT:"Ambient"}</expression>
-                                 <recovery_expression>{Template Server HP iLO SNMPv2:sensor.temp.value[cpqHeTemperatureCelsius.Ambient.{#SNMPINDEX}].max(5m)}&lt;{$TEMP_CRIT:"Ambient"}-3</recovery_expression>
-                              </dependency>
-                           </dependencies>
-                        </trigger_prototype>
-                        <trigger_prototype>
-                           <expression>{avg(5m)}&gt;{$TEMP_CRIT:"Ambient"}</expression>
-                           <recovery_mode>RECOVERY_EXPRESSION</recovery_mode>
-                           <recovery_expression>{max(5m)}&lt;{$TEMP_CRIT:"Ambient"}-3</recovery_expression>
-                           <name>Ambient: Temperature is above critical threshold: &gt;{$TEMP_CRIT:"Ambient"}</name>
-                           <opdata>Current value: {ITEM.LASTVALUE1}</opdata>
-                           <priority>HIGH</priority>
-                           <description>This trigger uses temperature sensor values as well as temperature sensor status if available</description>
-                        </trigger_prototype>
-                        <trigger_prototype>
-                           <expression>{avg(5m)}&lt;{$TEMP_CRIT_LOW:"Ambient"}</expression>
-                           <recovery_mode>RECOVERY_EXPRESSION</recovery_mode>
-                           <recovery_expression>{min(5m)}&gt;{$TEMP_CRIT_LOW:"Ambient"}+3</recovery_expression>
-                           <name>Ambient: Temperature is too low: &lt;{$TEMP_CRIT_LOW:"Ambient"}</name>
-                           <opdata>Current value: {ITEM.LASTVALUE1}</opdata>
-                           <priority>AVERAGE</priority>
-                        </trigger_prototype>
-                     </trigger_prototypes>
-                  </item_prototype>
-               </item_prototypes>
-            </discovery_rule>
-            <discovery_rule>
-               <name>Temperature Discovery CPU</name>
-               <type>SNMPV2</type>
-               <snmp_community>{$SNMP_COMMUNITY}</snmp_community>
-               <snmp_oid>discovery[{#SNMPVALUE},1.3.6.1.4.1.232.6.2.6.8.1.1,{#SENSOR_LOCALE},1.3.6.1.4.1.232.6.2.6.8.1.3]</snmp_oid>
-               <key>tempDescr.discovery.cpu</key>
-               <delay>1h</delay>
-               <filter>
-                  <evaltype>AND_OR</evaltype>
-                  <conditions>
-                     <condition>
-                        <macro>{#SENSOR_LOCALE}</macro>
-                        <value>6</value>
-                        <formulaid>A</formulaid>
-                     </condition>
-                  </conditions>
-               </filter>
-               <description>Scanning table of Temperature Sensor Entries: CPQHLTH-MIB::cpqHeTemperatureTable with cpu(6) filter</description>
-               <item_prototypes>
-                  <item_prototype>
-                     <name>CPU-{#SNMPINDEX}: Temperature</name>
-                     <type>SNMPV2</type>
-                     <snmp_community>{$SNMP_COMMUNITY}</snmp_community>
-                     <snmp_oid>1.3.6.1.4.1.232.6.2.6.8.1.4.{#SNMPINDEX}</snmp_oid>
-                     <key>sensor.temp.value[cpqHeTemperatureCelsius.CPU.{#SNMPINDEX}]</key>
-                     <delay>3m</delay>
-                     <value_type>FLOAT</value_type>
-                     <units>°C</units>
-                     <description>MIB: CPQHLTH-MIB&#13;
-Temperature readings of testpoint: CPU-{#SNMPINDEX}</description>
-                     <applications>
-                        <application>
-                           <name>Temperature</name>
-                        </application>
-                     </applications>
-                     <trigger_prototypes>
-                        <trigger_prototype>
-                           <expression>{avg(5m)}&gt;{$TEMP_WARN:"CPU"}</expression>
-                           <recovery_mode>RECOVERY_EXPRESSION</recovery_mode>
-                           <recovery_expression>{max(5m)}&lt;{$TEMP_WARN:"CPU"}-3</recovery_expression>
-                           <name>CPU-{#SNMPINDEX}: Temperature is above warning threshold: &gt;{$TEMP_WARN:"CPU"}</name>
-                           <opdata>Current value: {ITEM.LASTVALUE1}</opdata>
-                           <priority>WARNING</priority>
-                           <description>This trigger uses temperature sensor values as well as temperature sensor status if available</description>
-                           <dependencies>
-                              <dependency>
-                                 <name>CPU-{#SNMPINDEX}: Temperature is above critical threshold: &gt;{$TEMP_CRIT:"CPU"}</name>
-                                 <expression>{Template Server HP iLO SNMPv2:sensor.temp.value[cpqHeTemperatureCelsius.CPU.{#SNMPINDEX}].avg(5m)}&gt;{$TEMP_CRIT:"CPU"}</expression>
-                                 <recovery_expression>{Template Server HP iLO SNMPv2:sensor.temp.value[cpqHeTemperatureCelsius.CPU.{#SNMPINDEX}].max(5m)}&lt;{$TEMP_CRIT:"CPU"}-3</recovery_expression>
-                              </dependency>
-                           </dependencies>
-                        </trigger_prototype>
-                        <trigger_prototype>
-                           <expression>{avg(5m)}&gt;{$TEMP_CRIT:"CPU"}</expression>
-                           <recovery_mode>RECOVERY_EXPRESSION</recovery_mode>
-                           <recovery_expression>{max(5m)}&lt;{$TEMP_CRIT:"CPU"}-3</recovery_expression>
-                           <name>CPU-{#SNMPINDEX}: Temperature is above critical threshold: &gt;{$TEMP_CRIT:"CPU"}</name>
-                           <opdata>Current value: {ITEM.LASTVALUE1}</opdata>
-                           <priority>HIGH</priority>
-                           <description>This trigger uses temperature sensor values as well as temperature sensor status if available</description>
-                        </trigger_prototype>
-                        <trigger_prototype>
-                           <expression>{avg(5m)}&lt;{$TEMP_CRIT_LOW:"CPU"}</expression>
-                           <recovery_mode>RECOVERY_EXPRESSION</recovery_mode>
-                           <recovery_expression>{min(5m)}&gt;{$TEMP_CRIT_LOW:"CPU"}+3</recovery_expression>
-                           <name>CPU-{#SNMPINDEX}: Temperature is too low: &lt;{$TEMP_CRIT_LOW:"CPU"}</name>
-                           <opdata>Current value: {ITEM.LASTVALUE1}</opdata>
-                           <priority>AVERAGE</priority>
-                        </trigger_prototype>
-                     </trigger_prototypes>
-                  </item_prototype>
-               </item_prototypes>
-            </discovery_rule>
-            <discovery_rule>
-               <name>Temperature Discovery I/O</name>
-               <type>SNMPV2</type>
-               <snmp_community>{$SNMP_COMMUNITY}</snmp_community>
-               <snmp_oid>discovery[{#SNMPVALUE},1.3.6.1.4.1.232.6.2.6.8.1.1,{#SENSOR_LOCALE},1.3.6.1.4.1.232.6.2.6.8.1.3]</snmp_oid>
-               <key>tempDescr.discovery.io</key>
-               <delay>1h</delay>
-               <filter>
-                  <evaltype>AND_OR</evaltype>
-                  <conditions>
-                     <condition>
-                        <macro>{#SENSOR_LOCALE}</macro>
-                        <value>5</value>
-                        <formulaid>A</formulaid>
-                     </condition>
-                  </conditions>
-               </filter>
-               <description>Scanning table of Temperature Sensor Entries: CPQHLTH-MIB::cpqHeTemperatureTable with ioBoard(5) filter</description>
-               <item_prototypes>
-                  <item_prototype>
-                     <name>I/O-{#SNMPINDEX}: Temperature</name>
-                     <type>SNMPV2</type>
-                     <snmp_community>{$SNMP_COMMUNITY}</snmp_community>
-                     <snmp_oid>1.3.6.1.4.1.232.6.2.6.8.1.4.{#SNMPINDEX}</snmp_oid>
-                     <key>sensor.temp.value[cpqHeTemperatureCelsius."I/O.{#SNMPINDEX}"]</key>
-                     <delay>6m</delay>
-                     <value_type>FLOAT</value_type>
-                     <units>°C</units>
-                     <description>MIB: CPQHLTH-MIB&#13;
-Temperature readings of testpoint: I/O-{#SNMPINDEX}</description>
-                     <applications>
-                        <application>
-                           <name>Temperature</name>
-                        </application>
-                     </applications>
-                     <trigger_prototypes>
-                        <trigger_prototype>
-                           <expression>{avg(5m)}&gt;{$TEMP_WARN:"I/O"}</expression>
-                           <recovery_mode>RECOVERY_EXPRESSION</recovery_mode>
-                           <recovery_expression>{max(5m)}&lt;{$TEMP_WARN:"I/O"}-3</recovery_expression>
-                           <name>I/O-{#SNMPINDEX}: Temperature is above warning threshold: &gt;{$TEMP_WARN:"I/O"}</name>
-                           <opdata>Current value: {ITEM.LASTVALUE1}</opdata>
-                           <priority>WARNING</priority>
-                           <description>This trigger uses temperature sensor values as well as temperature sensor status if available</description>
-                           <dependencies>
-                              <dependency>
-                                 <name>I/O-{#SNMPINDEX}: Temperature is above critical threshold: &gt;{$TEMP_CRIT:"I/O"}</name>
-                                 <expression>{Template Server HP iLO SNMPv2:sensor.temp.value[cpqHeTemperatureCelsius."I/O.{#SNMPINDEX}"].avg(5m)}&gt;{$TEMP_CRIT:"I/O"}</expression>
-                                 <recovery_expression>{Template Server HP iLO SNMPv2:sensor.temp.value[cpqHeTemperatureCelsius."I/O.{#SNMPINDEX}"].max(5m)}&lt;{$TEMP_CRIT:"I/O"}-3</recovery_expression>
-                              </dependency>
-                           </dependencies>
-                        </trigger_prototype>
-                        <trigger_prototype>
-                           <expression>{avg(5m)}&gt;{$TEMP_CRIT:"I/O"}</expression>
-                           <recovery_mode>RECOVERY_EXPRESSION</recovery_mode>
-                           <recovery_expression>{max(5m)}&lt;{$TEMP_CRIT:"I/O"}-3</recovery_expression>
-                           <name>I/O-{#SNMPINDEX}: Temperature is above critical threshold: &gt;{$TEMP_CRIT:"I/O"}</name>
-                           <opdata>Current value: {ITEM.LASTVALUE1}</opdata>
-                           <priority>HIGH</priority>
-                           <description>This trigger uses temperature sensor values as well as temperature sensor status if available</description>
-                        </trigger_prototype>
-                        <trigger_prototype>
-                           <expression>{avg(5m)}&lt;{$TEMP_CRIT_LOW:"I/O"}</expression>
-                           <recovery_mode>RECOVERY_EXPRESSION</recovery_mode>
-                           <recovery_expression>{min(5m)}&gt;{$TEMP_CRIT_LOW:"I/O"}+3</recovery_expression>
-                           <name>I/O-{#SNMPINDEX}: Temperature is too low: &lt;{$TEMP_CRIT_LOW:"I/O"}</name>
-                           <opdata>Current value: {ITEM.LASTVALUE1}</opdata>
-                           <priority>AVERAGE</priority>
-                        </trigger_prototype>
-                     </trigger_prototypes>
-                  </item_prototype>
-               </item_prototypes>
-            </discovery_rule>
-            <discovery_rule>
-               <name>Temperature Discovery System</name>
-               <type>SNMPV2</type>
-               <snmp_community>{$SNMP_COMMUNITY}</snmp_community>
-               <snmp_oid>discovery[{#SNMPVALUE},1.3.6.1.4.1.232.6.2.6.8.1.1,{#SENSOR_LOCALE},1.3.6.1.4.1.232.6.2.6.8.1.3]</snmp_oid>
-               <key>tempDescr.discovery.io</key>
-               <delay>1h</delay>
-               <filter>
-                  <evaltype>AND_OR</evaltype>
-                  <conditions>
-                     <condition>
-                        <macro>{#SENSOR_LOCALE}</macro>
-                        <value>3</value>
-                        <formulaid>A</formulaid>
-                     </condition>
-                  </conditions>
-               </filter>
-               <description>Scanning table of Temperature Sensor Entries: CPQHLTH-MIB::cpqHeTemperatureTable with system(3) filter</description>
-               <item_prototypes>
-                  <item_prototype>
-                     <name>System-{#SNMPINDEX}: Temperature</name>
-                     <type>SNMPV2</type>
-                     <snmp_community>{$SNMP_COMMUNITY}</snmp_community>
-                     <snmp_oid>1.3.6.1.4.1.232.6.2.6.8.1.4.{#SNMPINDEX}</snmp_oid>
-                     <key>sensor.temp.value[cpqHeTemperatureCelsius.System.{#SNMPINDEX}]</key>
-                     <delay>6m</delay>
-                     <value_type>FLOAT</value_type>
-                     <units>°C</units>
-                     <description>MIB: CPQHLTH-MIB&#13;
-Temperature readings of testpoint: System-{#SNMPINDEX}</description>
-                     <applications>
-                        <application>
-                           <name>Temperature</name>
-                        </application>
-                     </applications>
-                     <trigger_prototypes>
-                        <trigger_prototype>
-                           <expression>{avg(5m)}&gt;{$TEMP_WARN:"Device"}</expression>
-                           <recovery_mode>RECOVERY_EXPRESSION</recovery_mode>
-                           <recovery_expression>{max(5m)}&lt;{$TEMP_WARN:"Device"}-3</recovery_expression>
-                           <name>System-{#SNMPINDEX}: Temperature is above warning threshold: &gt;{$TEMP_WARN:"Device"}</name>
-                           <opdata>Current value: {ITEM.LASTVALUE1}</opdata>
-                           <priority>WARNING</priority>
-                           <description>This trigger uses temperature sensor values as well as temperature sensor status if available</description>
-                           <dependencies>
-                              <dependency>
-                                 <name>System-{#SNMPINDEX}: Temperature is above critical threshold: &gt;{$TEMP_CRIT:"Device"}</name>
-                                 <expression>{Template Server HP iLO SNMPv2:sensor.temp.value[cpqHeTemperatureCelsius.System.{#SNMPINDEX}].avg(5m)}&gt;{$TEMP_CRIT:"Device"}</expression>
-                                 <recovery_expression>{Template Server HP iLO SNMPv2:sensor.temp.value[cpqHeTemperatureCelsius.System.{#SNMPINDEX}].max(5m)}&lt;{$TEMP_CRIT:"Device"}-3</recovery_expression>
-                              </dependency>
-                           </dependencies>
-                        </trigger_prototype>
-                        <trigger_prototype>
-                           <expression>{avg(5m)}&gt;{$TEMP_CRIT:"Device"}</expression>
-                           <recovery_mode>RECOVERY_EXPRESSION</recovery_mode>
-                           <recovery_expression>{max(5m)}&lt;{$TEMP_CRIT:"Device"}-3</recovery_expression>
-                           <name>System-{#SNMPINDEX}: Temperature is above critical threshold: &gt;{$TEMP_CRIT:"Device"}</name>
-                           <opdata>Current value: {ITEM.LASTVALUE1}</opdata>
-                           <priority>HIGH</priority>
-                           <description>This trigger uses temperature sensor values as well as temperature sensor status if available</description>
-                        </trigger_prototype>
-                        <trigger_prototype>
-                           <expression>{avg(5m)}&lt;{$TEMP_CRIT_LOW:"Device"}</expression>
-                           <recovery_mode>RECOVERY_EXPRESSION</recovery_mode>
-                           <recovery_expression>{min(5m)}&gt;{$TEMP_CRIT_LOW:"Device"}+3</recovery_expression>
-                           <name>System-{#SNMPINDEX}: Temperature is too low: &lt;{$TEMP_CRIT_LOW:"Device"}</name>
-                           <opdata>Current value: {ITEM.LASTVALUE1}</opdata>
-                           <priority>AVERAGE</priority>
-                        </trigger_prototype>
-                     </trigger_prototypes>
-                  </item_prototype>
-               </item_prototypes>
-            </discovery_rule>
-            <discovery_rule>
-               <name>Temperature Discovery Memory</name>
-               <type>SNMPV2</type>
-               <snmp_community>{$SNMP_COMMUNITY}</snmp_community>
-               <snmp_oid>discovery[{#SNMPVALUE},1.3.6.1.4.1.232.6.2.6.8.1.1,{#SENSOR_LOCALE},1.3.6.1.4.1.232.6.2.6.8.1.3]</snmp_oid>
-               <key>tempDescr.discovery.memory</key>
-               <delay>1h</delay>
-               <filter>
-                  <evaltype>AND_OR</evaltype>
-                  <conditions>
-                     <condition>
-                        <macro>{#SENSOR_LOCALE}</macro>
-                        <value>7</value>
-                        <formulaid>A</formulaid>
-                     </condition>
-                  </conditions>
-               </filter>
-               <description>Scanning table of Temperature Sensor Entries: CPQHLTH-MIB::cpqHeTemperatureTable with memory(7) filter</description>
-               <item_prototypes>
-                  <item_prototype>
-                     <name>Memory-{#SNMPINDEX}: Temperature</name>
-                     <type>SNMPV2</type>
-                     <snmp_community>{$SNMP_COMMUNITY}</snmp_community>
-                     <snmp_oid>1.3.6.1.4.1.232.6.2.6.8.1.4.{#SNMPINDEX}</snmp_oid>
-                     <key>sensor.temp.value[cpqHeTemperatureCelsius.Memory.{#SNMPINDEX}]</key>
-                     <delay>6m</delay>
-                     <value_type>FLOAT</value_type>
-                     <units>°C</units>
-                     <description>MIB: CPQHLTH-MIB&#13;
-Temperature readings of testpoint: Memory-{#SNMPINDEX}</description>
-                     <applications>
-                        <application>
-                           <name>Temperature</name>
-                        </application>
-                     </applications>
-                     <trigger_prototypes>
-                        <trigger_prototype>
-                           <expression>{avg(5m)}&gt;{$TEMP_WARN:"Memory"}</expression>
-                           <recovery_mode>RECOVERY_EXPRESSION</recovery_mode>
-                           <recovery_expression>{max(5m)}&lt;{$TEMP_WARN:"Memory"}-3</recovery_expression>
-                           <name>Memory-{#SNMPINDEX}: Temperature is above warning threshold: &gt;{$TEMP_WARN:"Memory"}</name>
-                           <opdata>Current value: {ITEM.LASTVALUE1}</opdata>
-                           <priority>WARNING</priority>
-                           <description>This trigger uses temperature sensor values as well as temperature sensor status if available</description>
-                           <dependencies>
-                              <dependency>
-                                 <name>Memory-{#SNMPINDEX}: Temperature is above critical threshold: &gt;{$TEMP_CRIT:"Memory"}</name>
-                                 <expression>{Template Server HP iLO SNMPv2:sensor.temp.value[cpqHeTemperatureCelsius.Memory.{#SNMPINDEX}].avg(5m)}&gt;{$TEMP_CRIT:"Memory"}</expression>
-                                 <recovery_expression>{Template Server HP iLO SNMPv2:sensor.temp.value[cpqHeTemperatureCelsius.Memory.{#SNMPINDEX}].max(5m)}&lt;{$TEMP_CRIT:"Memory"}-3</recovery_expression>
-                              </dependency>
-                           </dependencies>
-                        </trigger_prototype>
-                        <trigger_prototype>
-                           <expression>{avg(5m)}&gt;{$TEMP_CRIT:"Memory"}</expression>
-                           <recovery_mode>RECOVERY_EXPRESSION</recovery_mode>
-                           <recovery_expression>{max(5m)}&lt;{$TEMP_CRIT:"Memory"}-3</recovery_expression>
-                           <name>Memory-{#SNMPINDEX}: Temperature is above critical threshold: &gt;{$TEMP_CRIT:"Memory"}</name>
-                           <opdata>Current value: {ITEM.LASTVALUE1}</opdata>
-                           <priority>HIGH</priority>
-                           <description>This trigger uses temperature sensor values as well as temperature sensor status if available</description>
-                        </trigger_prototype>
-                        <trigger_prototype>
-                           <expression>{avg(5m)}&lt;{$TEMP_CRIT_LOW:"Memory"}</expression>
-                           <recovery_mode>RECOVERY_EXPRESSION</recovery_mode>
-                           <recovery_expression>{min(5m)}&gt;{$TEMP_CRIT_LOW:"Memory"}+3</recovery_expression>
-                           <name>Memory-{#SNMPINDEX}: Temperature is too low: &lt;{$TEMP_CRIT_LOW:"Memory"}</name>
-                           <opdata>Current value: {ITEM.LASTVALUE1}</opdata>
-                           <priority>AVERAGE</priority>
-                        </trigger_prototype>
-                     </trigger_prototypes>
-                  </item_prototype>
-               </item_prototypes>
-            </discovery_rule>
-            <discovery_rule>
-               <name>Temperature Discovery PSU</name>
-               <type>SNMPV2</type>
-               <snmp_community>{$SNMP_COMMUNITY}</snmp_community>
-               <snmp_oid>discovery[{#SNMPVALUE},1.3.6.1.4.1.232.6.2.6.8.1.1,{#SENSOR_LOCALE},1.3.6.1.4.1.232.6.2.6.8.1.3]</snmp_oid>
-               <key>tempDescr.discovery.psu</key>
-               <delay>1h</delay>
-               <filter>
-                  <evaltype>AND_OR</evaltype>
-                  <conditions>
-                     <condition>
-                        <macro>{#SENSOR_LOCALE}</macro>
-                        <value>10</value>
-                        <formulaid>A</formulaid>
-                     </condition>
-                  </conditions>
-               </filter>
-               <description>Scanning table of Temperature Sensor Entries: CPQHLTH-MIB::cpqHeTemperatureTable with powerSupply(10) filter</description>
-               <item_prototypes>
-                  <item_prototype>
-                     <name>PSU-{#SNMPINDEX}: Temperature</name>
-                     <type>SNMPV2</type>
-                     <snmp_community>{$SNMP_COMMUNITY}</snmp_community>
-                     <snmp_oid>1.3.6.1.4.1.232.6.2.6.8.1.4.{#SNMPINDEX}</snmp_oid>
-                     <key>sensor.temp.value[cpqHeTemperatureCelsius.PSU.{#SNMPINDEX}]</key>
-                     <delay>6m</delay>
-                     <value_type>FLOAT</value_type>
-                     <units>°C</units>
-                     <description>MIB: CPQHLTH-MIB&#13;
-Temperature readings of testpoint: PSU-{#SNMPINDEX}</description>
-                     <applications>
-                        <application>
-                           <name>Temperature</name>
-                        </application>
-                     </applications>
-                     <trigger_prototypes>
-                        <trigger_prototype>
-                           <expression>{avg(5m)}&gt;{$TEMP_WARN:"PSU"}</expression>
-                           <recovery_mode>RECOVERY_EXPRESSION</recovery_mode>
-                           <recovery_expression>{max(5m)}&lt;{$TEMP_WARN:"PSU"}-3</recovery_expression>
-                           <name>PSU-{#SNMPINDEX}: Temperature is above warning threshold: &gt;{$TEMP_WARN:"PSU"}</name>
-                           <opdata>Current value: {ITEM.LASTVALUE1}</opdata>
-                           <priority>WARNING</priority>
-                           <description>This trigger uses temperature sensor values as well as temperature sensor status if available</description>
-                           <dependencies>
-                              <dependency>
-                                 <name>PSU-{#SNMPINDEX}: Temperature is above critical threshold: &gt;{$TEMP_CRIT:"PSU"}</name>
-                                 <expression>{Template Server HP iLO SNMPv2:sensor.temp.value[cpqHeTemperatureCelsius.PSU.{#SNMPINDEX}].avg(5m)}&gt;{$TEMP_CRIT:"PSU"}</expression>
-                                 <recovery_expression>{Template Server HP iLO SNMPv2:sensor.temp.value[cpqHeTemperatureCelsius.PSU.{#SNMPINDEX}].max(5m)}&lt;{$TEMP_CRIT:"PSU"}-3</recovery_expression>
-                              </dependency>
-                           </dependencies>
-                        </trigger_prototype>
-                        <trigger_prototype>
-                           <expression>{avg(5m)}&gt;{$TEMP_CRIT:"PSU"}</expression>
-                           <recovery_mode>RECOVERY_EXPRESSION</recovery_mode>
-                           <recovery_expression>{max(5m)}&lt;{$TEMP_CRIT:"PSU"}-3</recovery_expression>
-                           <name>PSU-{#SNMPINDEX}: Temperature is above critical threshold: &gt;{$TEMP_CRIT:"PSU"}</name>
-                           <opdata>Current value: {ITEM.LASTVALUE1}</opdata>
-                           <priority>HIGH</priority>
-                           <description>This trigger uses temperature sensor values as well as temperature sensor status if available</description>
-                        </trigger_prototype>
-                        <trigger_prototype>
-                           <expression>{avg(5m)}&lt;{$TEMP_CRIT_LOW:"PSU"}</expression>
-                           <recovery_mode>RECOVERY_EXPRESSION</recovery_mode>
-                           <recovery_expression>{min(5m)}&gt;{$TEMP_CRIT_LOW:"PSU"}+3</recovery_expression>
-                           <name>PSU-{#SNMPINDEX}: Temperature is too low: &lt;{$TEMP_CRIT_LOW:"PSU"}</name>
-                           <opdata>Current value: {ITEM.LASTVALUE1}</opdata>
-                           <priority>AVERAGE</priority>
-                        </trigger_prototype>
-                     </trigger_prototypes>
-                  </item_prototype>
-               </item_prototypes>
-            </discovery_rule>
-            <discovery_rule>
-               <name>Virtual Disk Discovery</name>
-               <type>SNMPV2</type>
-               <snmp_community>{$SNMP_COMMUNITY}</snmp_community>
-               <snmp_oid>discovery[{#SNMPVALUE},1.3.6.1.4.1.232.3.2.3.1.1.2,{#DISK_NAME},1.3.6.1.4.1.232.3.2.3.1.1.14]</snmp_oid>
-               <key>virtualdisk.discovery</key>
-               <delay>1h</delay>
-               <description>CPQIDA-MIB::cpqDaLogDrvTable</description>
-               <item_prototypes>
-                  <item_prototype>
-                     <name>Disk {#SNMPINDEX}({#DISK_NAME}): Layout type</name>
-                     <type>SNMPV2</type>
-                     <snmp_community>{$SNMP_COMMUNITY}</snmp_community>
-                     <snmp_oid>1.3.6.1.4.1.232.3.2.3.1.1.3.{#SNMPINDEX}</snmp_oid>
-                     <key>system.hw.virtualdisk.layout[cpqDaLogDrvFaultTol.{#SNMPINDEX}]</key>
-                     <delay>1h</delay>
-                     <history>2w</history>
-                     <description>Logical Drive Fault Tolerance.&#13;
+                    </trigger_prototypes>
+                    <graph_prototypes>
+                        <graph_prototype>
+                            <name>{#SNMPINDEX}: Temperature Reading</name>
+                            <show_work_period>NO</show_work_period>
+                            <graph_items>
+                                <graph_item>
+                                    <color>0080FF</color>
+                                    <item>
+                                        <host>Template Server HP iLO SNMPv2</host>
+                                        <key>sensor.temp.value[cpqHeTemperatureCelsius.{#SNMPINDEX}]</key>
+                                    </item>
+                                </graph_item>
+                            </graph_items>
+                        </graph_prototype>
+                    </graph_prototypes>
+                </discovery_rule>
+                <discovery_rule>
+                    <name>Virtual Disk Discovery</name>
+                    <type>SNMP_AGENT</type>
+                    <snmp_oid>discovery[{#SNMPVALUE},1.3.6.1.4.1.232.3.2.3.1.1.2,{#DISK_NAME},1.3.6.1.4.1.232.3.2.3.1.1.14]</snmp_oid>
+                    <key>virtualdisk.discovery</key>
+                    <delay>1h</delay>
+                    <description>CPQIDA-MIB::cpqDaLogDrvTable</description>
+                    <item_prototypes>
+                        <item_prototype>
+                            <name>Disk {#SNMPINDEX}({#DISK_NAME}): Layout type</name>
+                            <type>SNMP_AGENT</type>
+                            <snmp_oid>1.3.6.1.4.1.232.3.2.3.1.1.3.{#SNMPINDEX}</snmp_oid>
+                            <key>system.hw.virtualdisk.layout[cpqDaLogDrvFaultTol.{#SNMPINDEX}]</key>
+                            <delay>1h</delay>
+                            <history>2w</history>
+                            <description>Logical Drive Fault Tolerance.&#13;
 This shows the fault tolerance mode of the logical drive.</description>
-                     <applications>
-                        <application>
-                           <name>Virtual disks</name>
-                        </application>
-                     </applications>
-                     <valuemap>
-                        <name>CPQIDA-MIB::cpqDaLogDrvFaultTol</name>
-                     </valuemap>
-                  </item_prototype>
-                  <item_prototype>
-                     <name>Disk {#SNMPINDEX}({#DISK_NAME}): Disk size</name>
-                     <type>SNMPV2</type>
-                     <snmp_community>{$SNMP_COMMUNITY}</snmp_community>
-                     <snmp_oid>1.3.6.1.4.1.232.3.2.3.1.1.9.{#SNMPINDEX}</snmp_oid>
-                     <key>system.hw.virtualdisk.size[cpqDaLogDrvSize.{#SNMPINDEX}]</key>
-                     <delay>1h</delay>
-                     <history>2w</history>
-                     <trends>0d</trends>
-                     <units>B</units>
-                     <description>Logical Drive Size.&#13;
+                            <applications>
+                                <application>
+                                    <name>Virtual Disks</name>
+                                </application>
+                            </applications>
+                            <valuemap>
+                                <name>CPQIDA-MIB::cpqDaLogDrvFaultTol</name>
+                            </valuemap>
+                        </item_prototype>
+                        <item_prototype>
+                            <name>Disk {#SNMPINDEX}({#DISK_NAME}): Disk size</name>
+                            <type>SNMP_AGENT</type>
+                            <snmp_oid>1.3.6.1.4.1.232.3.2.3.1.1.9.{#SNMPINDEX}</snmp_oid>
+                            <key>system.hw.virtualdisk.size[cpqDaLogDrvSize.{#SNMPINDEX}]</key>
+                            <delay>1h</delay>
+                            <history>2w</history>
+                            <trends>0d</trends>
+                            <units>B</units>
+                            <description>Logical Drive Size.&#13;
 This is the size of the logical drive in megabytes.  This value&#13;
 is calculated using the value 1,048,576 (2^20) as a megabyte.&#13;
 Drive manufacturers sometimes use the number 1,000,000 as a&#13;
 megabyte when giving drive capacities so this value may&#13;
 differ from the advertised size of a drive.</description>
-                     <applications>
-                        <application>
-                           <name>Virtual disks</name>
-                        </application>
-                     </applications>
-                     <preprocessing>
-                        <step>
-                           <type>MULTIPLIER</type>
-                           <params>1048576</params>
-                        </step>
-                     </preprocessing>
-                  </item_prototype>
-                  <item_prototype>
-                     <name>Disk {#SNMPINDEX}({#DISK_NAME}): Status</name>
-                     <type>SNMPV2</type>
-                     <snmp_community>{$SNMP_COMMUNITY}</snmp_community>
-                     <snmp_oid>1.3.6.1.4.1.232.3.2.3.1.1.4.{#SNMPINDEX}</snmp_oid>
-                     <key>system.hw.virtualdisk.status[cpqDaLogDrvStatus.{#SNMPINDEX}]</key>
-                     <delay>3m</delay>
-                     <history>2w</history>
-                     <description>Logical Drive Status.</description>
-                     <applications>
-                        <application>
-                           <name>Virtual disks</name>
-                        </application>
-                     </applications>
-                     <valuemap>
-                        <name>CPQIDA-MIB::cpqDaLogDrvStatus</name>
-                     </valuemap>
-                     <trigger_prototypes>
-                        <trigger_prototype>
-                           <expression>{count(#1,{$VDISK_CRIT_STATUS},eq)}=1</expression>
-                           <name>Disk {#SNMPINDEX}({#DISK_NAME}): Virtual disk failed</name>
-                           <opdata>Current state: {ITEM.LASTVALUE1}</opdata>
-                           <priority>HIGH</priority>
-                           <description>Please check virtual disk for warnings or errors</description>
-                        </trigger_prototype>
-                        <trigger_prototype>
-                           <expression>{count(#1,{$VDISK_OK_STATUS},ne)}=1</expression>
-                           <name>Disk {#SNMPINDEX}({#DISK_NAME}): Virtual disk is not in OK state</name>
-                           <opdata>Current state: {ITEM.LASTVALUE1}</opdata>
-                           <priority>WARNING</priority>
-                           <description>Please check virtual disk for warnings or errors</description>
-                           <dependencies>
-                              <dependency>
-                                 <name>Disk {#SNMPINDEX}({#DISK_NAME}): Virtual disk failed</name>
-                                 <expression>{Template Server HP iLO SNMPv2:system.hw.virtualdisk.status[cpqDaLogDrvStatus.{#SNMPINDEX}].count(#1,{$VDISK_CRIT_STATUS},eq)}=1</expression>
-                              </dependency>
-                           </dependencies>
-                        </trigger_prototype>
-                     </trigger_prototypes>
-                  </item_prototype>
-               </item_prototypes>
-            </discovery_rule>
-         </discovery_rules>
-         <macros>
-            <macro>
-               <macro>{$DISK_ARRAY_CACHE_BATTERY_CRIT_STATUS:"capacitorFailed"}</macro>
-               <value>7</value>
-            </macro>
-            <macro>
-               <macro>{$DISK_ARRAY_CACHE_BATTERY_CRIT_STATUS:"failed"}</macro>
-               <value>4</value>
-            </macro>
-            <macro>
-               <macro>{$DISK_ARRAY_CACHE_BATTERY_WARN_STATUS:"degraded"}</macro>
-               <value>5</value>
-            </macro>
-            <macro>
-               <macro>{$DISK_ARRAY_CACHE_BATTERY_WARN_STATUS:"notPresent"}</macro>
-               <value>6</value>
-            </macro>
-            <macro>
-               <macro>{$DISK_ARRAY_CACHE_CRIT_STATUS:"cacheModCriticalFailure"}</macro>
-               <value>8</value>
-            </macro>
-            <macro>
-               <macro>{$DISK_ARRAY_CACHE_OK_STATUS:"enabled"}</macro>
-               <value>3</value>
-            </macro>
-            <macro>
-               <macro>{$DISK_ARRAY_CACHE_WARN_STATUS:"cacheModDegradedFailsafeSpeed"}</macro>
-               <value>7</value>
-            </macro>
-            <macro>
-               <macro>{$DISK_ARRAY_CACHE_WARN_STATUS:"cacheModFlashMemNotAttached"}</macro>
-               <value>6</value>
-            </macro>
-            <macro>
-               <macro>{$DISK_ARRAY_CACHE_WARN_STATUS:"cacheReadCacheNotMapped"}</macro>
-               <value>9</value>
-            </macro>
-            <macro>
-               <macro>{$DISK_ARRAY_CACHE_WARN_STATUS:"invalid"}</macro>
-               <value>2</value>
-            </macro>
-            <macro>
-               <macro>{$DISK_ARRAY_CRIT_STATUS}</macro>
-               <value>4</value>
-            </macro>
-            <macro>
-               <macro>{$DISK_ARRAY_WARN_STATUS}</macro>
-               <value>3</value>
-            </macro>
-            <macro>
-               <macro>{$DISK_FAIL_STATUS}</macro>
-               <value>3</value>
-            </macro>
-            <macro>
-               <macro>{$DISK_SMART_FAIL_STATUS:"replaceDrive"}</macro>
-               <value>3</value>
-            </macro>
-            <macro>
-               <macro>{$DISK_SMART_FAIL_STATUS:"replaceDriveSSDWearOut"}</macro>
-               <value>4</value>
-            </macro>
-            <macro>
-               <macro>{$DISK_WARN_STATUS}</macro>
-               <value>4</value>
-            </macro>
-            <macro>
-               <macro>{$FAN_CRIT_STATUS}</macro>
-               <value>4</value>
-            </macro>
-            <macro>
-               <macro>{$FAN_WARN_STATUS}</macro>
-               <value>3</value>
-            </macro>
-            <macro>
-               <macro>{$HEALTH_CRIT_STATUS}</macro>
-               <value>4</value>
-            </macro>
-            <macro>
-               <macro>{$HEALTH_WARN_STATUS}</macro>
-               <value>3</value>
-            </macro>
-            <macro>
-               <macro>{$PSU_CRIT_STATUS}</macro>
-               <value>4</value>
-            </macro>
-            <macro>
-               <macro>{$PSU_WARN_STATUS}</macro>
-               <value>3</value>
-            </macro>
-            <macro>
-               <macro>{$TEMP_CRIT_LOW}</macro>
-               <value>5</value>
-            </macro>
-            <macro>
-               <macro>{$TEMP_CRIT:"Ambient"}</macro>
-               <value>35</value>
-            </macro>
-            <macro>
-               <macro>{$TEMP_CRIT}</macro>
-               <value>60</value>
-            </macro>
-            <macro>
-               <macro>{$TEMP_WARN:"Ambient"}</macro>
-               <value>30</value>
-            </macro>
-            <macro>
-               <macro>{$TEMP_WARN}</macro>
-               <value>50</value>
-            </macro>
-            <macro>
-               <macro>{$VDISK_CRIT_STATUS}</macro>
-               <value>3</value>
-            </macro>
-            <macro>
-               <macro>{$VDISK_OK_STATUS}</macro>
-               <value>2</value>
-            </macro>
-         </macros>
-      </template>
-   </templates>
-   <value_maps>
-      <value_map>
-         <name>CPQSINFO-MIB::status</name>
-         <mappings>
-            <mapping>
-               <value>1</value>
-               <newvalue>other</newvalue>
-            </mapping>
-            <mapping>
-               <value>2</value>
-               <newvalue>ok</newvalue>
-            </mapping>
-            <mapping>
-               <value>3</value>
-               <newvalue>degraded</newvalue>
-            </mapping>
-            <mapping>
-               <value>4</value>
-               <newvalue>failed</newvalue>
-            </mapping>
-         </mappings>
-      </value_map>
-      <value_map>
-         <name>CPQHLTH-MIB::cpqHeTemperatureLocale</name>
-         <mappings>
-            <mapping>
-               <value>1</value>
-               <newvalue>other</newvalue>
-            </mapping>
-            <mapping>
-               <value>2</value>
-               <newvalue>unknown</newvalue>
-            </mapping>
-            <mapping>
-               <value>3</value>
-               <newvalue>system</newvalue>
-            </mapping>
-            <mapping>
-               <value>4</value>
-               <newvalue>systemBoard</newvalue>
-            </mapping>
-            <mapping>
-               <value>5</value>
-               <newvalue>ioBoard</newvalue>
-            </mapping>
-            <mapping>
-               <value>6</value>
-               <newvalue>cpu</newvalue>
-            </mapping>
-            <mapping>
-               <value>7</value>
-               <newvalue>memory</newvalue>
-            </mapping>
-            <mapping>
-               <value>8</value>
-               <newvalue>storage</newvalue>
-            </mapping>
-            <mapping>
-               <value>9</value>
-               <newvalue>removableMedia</newvalue>
-            </mapping>
-            <mapping>
-               <value>10</value>
-               <newvalue>powerSupply</newvalue>
-            </mapping>
-            <mapping>
-               <value>11</value>
-               <newvalue>ambient</newvalue>
-            </mapping>
-            <mapping>
-               <value>12</value>
-               <newvalue>chassis</newvalue>
-            </mapping>
-            <mapping>
-               <value>13</value>
-               <newvalue>bridgeCard</newvalue>
-            </mapping>
-         </mappings>
-      </value_map>
-      <value_map>
-         <name>CPQIDA-MIB::cpqDaCntlrModel</name>
-         <mappings>
-            <mapping>
-               <value>1</value>
-               <newvalue>other</newvalue>
-            </mapping>
-            <mapping>
-               <value>2</value>
-               <newvalue>ida</newvalue>
-            </mapping>
-            <mapping>
-               <value>3</value>
-               <newvalue>idaExpansion</newvalue>
-            </mapping>
-            <mapping>
-               <value>4</value>
-               <newvalue>ida-2</newvalue>
-            </mapping>
-            <mapping>
-               <value>5</value>
-               <newvalue>smart</newvalue>
-            </mapping>
-            <mapping>
-               <value>6</value>
-               <newvalue>smart-2e</newvalue>
-            </mapping>
-            <mapping>
-               <value>7</value>
-               <newvalue>smart-2p</newvalue>
-            </mapping>
-            <mapping>
-               <value>8</value>
-               <newvalue>smart-2sl</newvalue>
-            </mapping>
-            <mapping>
-               <value>9</value>
-               <newvalue>smart-3100es</newvalue>
-            </mapping>
-            <mapping>
-               <value>10</value>
-               <newvalue>smart-3200</newvalue>
-            </mapping>
-            <mapping>
-               <value>11</value>
-               <newvalue>smart-2dh</newvalue>
-            </mapping>
-            <mapping>
-               <value>12</value>
-               <newvalue>smart-221</newvalue>
-            </mapping>
-            <mapping>
-               <value>13</value>
-               <newvalue>sa-4250es</newvalue>
-            </mapping>
-            <mapping>
-               <value>14</value>
-               <newvalue>sa-4200</newvalue>
-            </mapping>
-            <mapping>
-               <value>15</value>
-               <newvalue>sa-integrated</newvalue>
-            </mapping>
-            <mapping>
-               <value>16</value>
-               <newvalue>sa-431</newvalue>
-            </mapping>
-            <mapping>
-               <value>17</value>
-               <newvalue>sa-5300</newvalue>
-            </mapping>
-            <mapping>
-               <value>18</value>
-               <newvalue>raidLc2</newvalue>
-            </mapping>
-            <mapping>
-               <value>19</value>
-               <newvalue>sa-5i</newvalue>
-            </mapping>
-            <mapping>
-               <value>20</value>
-               <newvalue>sa-532</newvalue>
-            </mapping>
-            <mapping>
-               <value>21</value>
-               <newvalue>sa-5312</newvalue>
-            </mapping>
-            <mapping>
-               <value>22</value>
-               <newvalue>sa-641</newvalue>
-            </mapping>
-            <mapping>
-               <value>23</value>
-               <newvalue>sa-642</newvalue>
-            </mapping>
-            <mapping>
-               <value>24</value>
-               <newvalue>sa-6400</newvalue>
-            </mapping>
-            <mapping>
-               <value>25</value>
-               <newvalue>sa-6400em</newvalue>
-            </mapping>
-            <mapping>
-               <value>26</value>
-               <newvalue>sa-6i</newvalue>
-            </mapping>
-            <mapping>
-               <value>27</value>
-               <newvalue>sa-generic</newvalue>
-            </mapping>
-            <mapping>
-               <value>29</value>
-               <newvalue>sa-p600</newvalue>
-            </mapping>
-            <mapping>
-               <value>30</value>
-               <newvalue>sa-p400</newvalue>
-            </mapping>
-            <mapping>
-               <value>31</value>
-               <newvalue>sa-e200</newvalue>
-            </mapping>
-            <mapping>
-               <value>32</value>
-               <newvalue>sa-e200i</newvalue>
-            </mapping>
-            <mapping>
-               <value>33</value>
-               <newvalue>sa-p400i</newvalue>
-            </mapping>
-            <mapping>
-               <value>34</value>
-               <newvalue>sa-p800</newvalue>
-            </mapping>
-            <mapping>
-               <value>35</value>
-               <newvalue>sa-e500</newvalue>
-            </mapping>
-            <mapping>
-               <value>36</value>
-               <newvalue>sa-p700m</newvalue>
-            </mapping>
-            <mapping>
-               <value>37</value>
-               <newvalue>sa-p212</newvalue>
-            </mapping>
-            <mapping>
-               <value>38</value>
-               <newvalue>sa-p410</newvalue>
-            </mapping>
-            <mapping>
-               <value>39</value>
-               <newvalue>sa-p410i</newvalue>
-            </mapping>
-            <mapping>
-               <value>40</value>
-               <newvalue>sa-p411</newvalue>
-            </mapping>
-            <mapping>
-               <value>41</value>
-               <newvalue>sa-b110i</newvalue>
-            </mapping>
-            <mapping>
-               <value>42</value>
-               <newvalue>sa-p712m</newvalue>
-            </mapping>
-            <mapping>
-               <value>43</value>
-               <newvalue>sa-p711m</newvalue>
-            </mapping>
-            <mapping>
-               <value>44</value>
-               <newvalue>sa-p812</newvalue>
-            </mapping>
-            <mapping>
-               <value>45</value>
-               <newvalue>sw-1210m</newvalue>
-            </mapping>
-            <mapping>
-               <value>46</value>
-               <newvalue>sa-p220i</newvalue>
-            </mapping>
-            <mapping>
-               <value>47</value>
-               <newvalue>sa-p222</newvalue>
-            </mapping>
-            <mapping>
-               <value>48</value>
-               <newvalue>sa-p420</newvalue>
-            </mapping>
-            <mapping>
-               <value>49</value>
-               <newvalue>sa-p420i</newvalue>
-            </mapping>
-            <mapping>
-               <value>50</value>
-               <newvalue>sa-p421</newvalue>
-            </mapping>
-            <mapping>
-               <value>51</value>
-               <newvalue>sa-b320i</newvalue>
-            </mapping>
-            <mapping>
-               <value>52</value>
-               <newvalue>sa-p822</newvalue>
-            </mapping>
-            <mapping>
-               <value>53</value>
-               <newvalue>sa-p721m</newvalue>
-            </mapping>
-            <mapping>
-               <value>54</value>
-               <newvalue>sa-b120i</newvalue>
-            </mapping>
-            <mapping>
-               <value>55</value>
-               <newvalue>hps-1224</newvalue>
-            </mapping>
-            <mapping>
-               <value>56</value>
-               <newvalue>hps-1228</newvalue>
-            </mapping>
-            <mapping>
-               <value>57</value>
-               <newvalue>hps-1228m</newvalue>
-            </mapping>
-            <mapping>
-               <value>58</value>
-               <newvalue>sa-p822se</newvalue>
-            </mapping>
-            <mapping>
-               <value>59</value>
-               <newvalue>hps-1224e</newvalue>
-            </mapping>
-            <mapping>
-               <value>60</value>
-               <newvalue>hps-1228e</newvalue>
-            </mapping>
-            <mapping>
-               <value>61</value>
-               <newvalue>hps-1228em</newvalue>
-            </mapping>
-            <mapping>
-               <value>62</value>
-               <newvalue>sa-p230i</newvalue>
-            </mapping>
-            <mapping>
-               <value>63</value>
-               <newvalue>sa-p430i</newvalue>
-            </mapping>
-            <mapping>
-               <value>64</value>
-               <newvalue>sa-p430</newvalue>
-            </mapping>
-            <mapping>
-               <value>65</value>
-               <newvalue>sa-p431</newvalue>
-            </mapping>
-            <mapping>
-               <value>66</value>
-               <newvalue>sa-p731m</newvalue>
-            </mapping>
-            <mapping>
-               <value>67</value>
-               <newvalue>sa-p830i</newvalue>
-            </mapping>
-            <mapping>
-               <value>68</value>
-               <newvalue>sa-p830</newvalue>
-            </mapping>
-            <mapping>
-               <value>69</value>
-               <newvalue>sa-p831</newvalue>
-            </mapping>
-            <mapping>
-               <value>70</value>
-               <newvalue>sa-p530</newvalue>
-            </mapping>
-            <mapping>
-               <value>71</value>
-               <newvalue>sa-p531</newvalue>
-            </mapping>
-            <mapping>
-               <value>72</value>
-               <newvalue>sa-p244br</newvalue>
-            </mapping>
-            <mapping>
-               <value>73</value>
-               <newvalue>sa-p246br</newvalue>
-            </mapping>
-            <mapping>
-               <value>74</value>
-               <newvalue>sa-p440</newvalue>
-            </mapping>
-            <mapping>
-               <value>75</value>
-               <newvalue>sa-p440ar</newvalue>
-            </mapping>
-            <mapping>
-               <value>76</value>
-               <newvalue>sa-p441</newvalue>
-            </mapping>
-            <mapping>
-               <value>77</value>
-               <newvalue>sa-p741m</newvalue>
-            </mapping>
-            <mapping>
-               <value>78</value>
-               <newvalue>sa-p840</newvalue>
-            </mapping>
-            <mapping>
-               <value>79</value>
-               <newvalue>sa-p841</newvalue>
-            </mapping>
-            <mapping>
-               <value>80</value>
-               <newvalue>sh-h240ar</newvalue>
-            </mapping>
-            <mapping>
-               <value>81</value>
-               <newvalue>sh-h244br</newvalue>
-            </mapping>
-            <mapping>
-               <value>82</value>
-               <newvalue>sh-h240</newvalue>
-            </mapping>
-            <mapping>
-               <value>83</value>
-               <newvalue>sh-h241</newvalue>
-            </mapping>
-            <mapping>
-               <value>84</value>
-               <newvalue>sa-b140i</newvalue>
-            </mapping>
-            <mapping>
-               <value>85</value>
-               <newvalue>sh-generic</newvalue>
-            </mapping>
-            <mapping>
-               <value>88</value>
-               <newvalue>sa-p840ar</newvalue>
-            </mapping>
-         </mappings>
-      </value_map>
-      <value_map>
-         <name>CPQIDA-MIB::cpqDaPhyDrvStatus</name>
-         <mappings>
-            <mapping>
-               <value>1</value>
-               <newvalue>other</newvalue>
-            </mapping>
-            <mapping>
-               <value>2</value>
-               <newvalue>ok</newvalue>
-            </mapping>
-            <mapping>
-               <value>3</value>
-               <newvalue>failed</newvalue>
-            </mapping>
-            <mapping>
-               <value>4</value>
-               <newvalue>predictiveFailure</newvalue>
-            </mapping>
-         </mappings>
-      </value_map>
-      <value_map>
-         <name>CPQIDA-MIB::cpqDaPhyDrvSmartStatus</name>
-         <mappings>
-            <mapping>
-               <value>1</value>
-               <newvalue>other</newvalue>
-            </mapping>
-            <mapping>
-               <value>2</value>
-               <newvalue>ok</newvalue>
-            </mapping>
-            <mapping>
-               <value>3</value>
-               <newvalue>replaceDrive</newvalue>
-            </mapping>
-            <mapping>
-               <value>4</value>
-               <newvalue>replaceDriveSSDWearOut</newvalue>
-            </mapping>
-         </mappings>
-      </value_map>
-      <value_map>
-         <name>CPQIDA-MIB::cpqDaAccelStatus</name>
-         <mappings>
-            <mapping>
-               <value>1</value>
-               <newvalue>other</newvalue>
-            </mapping>
-            <mapping>
-               <value>2</value>
-               <newvalue>invalid</newvalue>
-            </mapping>
-            <mapping>
-               <value>3</value>
-               <newvalue>enabled</newvalue>
-            </mapping>
-            <mapping>
-               <value>4</value>
-               <newvalue>tmpDisabled</newvalue>
-            </mapping>
-            <mapping>
-               <value>5</value>
-               <newvalue>permDisabled</newvalue>
-            </mapping>
-            <mapping>
-               <value>6</value>
-               <newvalue>cacheModFlashMemNotAttached</newvalue>
-            </mapping>
-            <mapping>
-               <value>7</value>
-               <newvalue>cacheModDegradedFailsafeSpeed</newvalue>
-            </mapping>
-            <mapping>
-               <value>8</value>
-               <newvalue>cacheModCriticalFailure</newvalue>
-            </mapping>
-            <mapping>
-               <value>9</value>
-               <newvalue>cacheReadCacheNotMapped</newvalue>
-            </mapping>
-         </mappings>
-      </value_map>
-      <value_map>
-         <name>CPQIDA-MIB::cpqDaAccelBattery</name>
-         <mappings>
-            <mapping>
-               <value>1</value>
-               <newvalue>Other</newvalue>
-            </mapping>
-            <mapping>
-               <value>2</value>
-               <newvalue>Ok</newvalue>
-            </mapping>
-            <mapping>
-               <value>3</value>
-               <newvalue>Recharging</newvalue>
-            </mapping>
-            <mapping>
-               <value>4</value>
-               <newvalue>Failed</newvalue>
-            </mapping>
-            <mapping>
-               <value>5</value>
-               <newvalue>Degraded</newvalue>
-            </mapping>
-            <mapping>
-               <value>6</value>
-               <newvalue>Not Present</newvalue>
-            </mapping>
-            <mapping>
-               <value>7</value>
-               <newvalue>Capacitor failed</newvalue>
-            </mapping>
-         </mappings>
-      </value_map>
-      <value_map>
-         <name>CPQIDA-MIB::cpqDaPhyDrvMediaType</name>
-         <mappings>
-            <mapping>
-               <value>1</value>
-               <newvalue>Other</newvalue>
-            </mapping>
-            <mapping>
-               <value>2</value>
-               <newvalue>rotatingPlatters</newvalue>
-            </mapping>
-            <mapping>
-               <value>3</value>
-               <newvalue>solidState</newvalue>
-            </mapping>
-         </mappings>
-      </value_map>
-      <value_map>
-         <name>CPQIDA-MIB::cpqDaLogDrvFaultTol</name>
-         <mappings>
-            <mapping>
-               <value>0</value>
-               <newvalue>other</newvalue>
-            </mapping>
-            <mapping>
-               <value>2</value>
-               <newvalue>none</newvalue>
-            </mapping>
-            <mapping>
-               <value>3</value>
-               <newvalue>RAID-1/RAID-10</newvalue>
-            </mapping>
-            <mapping>
-               <value>4</value>
-               <newvalue>RAID-4</newvalue>
-            </mapping>
-            <mapping>
-               <value>5</value>
-               <newvalue>RAID-5</newvalue>
-            </mapping>
-            <mapping>
-               <value>7</value>
-               <newvalue>RAID-6</newvalue>
-            </mapping>
-            <mapping>
-               <value>8</value>
-               <newvalue>RAID-50</newvalue>
-            </mapping>
-            <mapping>
-               <value>9</value>
-               <newvalue>RAID-60</newvalue>
-            </mapping>
-            <mapping>
-               <value>10</value>
-               <newvalue>RAID-1 ADM</newvalue>
-            </mapping>
-            <mapping>
-               <value>11</value>
-               <newvalue>RAID-10 ADM</newvalue>
-            </mapping>
-         </mappings>
-      </value_map>
-      <value_map>
-         <name>CPQIDA-MIB::cpqDaLogDrvStatus</name>
-         <mappings>
-            <mapping>
-               <value>1</value>
-               <newvalue>other</newvalue>
-            </mapping>
-            <mapping>
-               <value>2</value>
-               <newvalue>ok</newvalue>
-            </mapping>
-            <mapping>
-               <value>3</value>
-               <newvalue>failed</newvalue>
-            </mapping>
-            <mapping>
-               <value>4</value>
-               <newvalue>unconfigured</newvalue>
-            </mapping>
-            <mapping>
-               <value>5</value>
-               <newvalue>recovering</newvalue>
-            </mapping>
-            <mapping>
-               <value>6</value>
-               <newvalue>readyForRebuild</newvalue>
-            </mapping>
-            <mapping>
-               <value>7</value>
-               <newvalue>rebuilding</newvalue>
-            </mapping>
-            <mapping>
-               <value>8</value>
-               <newvalue>wrongDrive</newvalue>
-            </mapping>
-            <mapping>
-               <value>9</value>
-               <newvalue>badConnect</newvalue>
-            </mapping>
-            <mapping>
-               <value>10</value>
-               <newvalue>overheating</newvalue>
-            </mapping>
-            <mapping>
-               <value>11</value>
-               <newvalue>shutdown</newvalue>
-            </mapping>
-            <mapping>
-               <value>12</value>
-               <newvalue>expanding</newvalue>
-            </mapping>
-            <mapping>
-               <value>13</value>
-               <newvalue>notAvailable</newvalue>
-            </mapping>
-            <mapping>
-               <value>14</value>
-               <newvalue>queuedForExpansion</newvalue>
-            </mapping>
-            <mapping>
-               <value>15</value>
-               <newvalue>multipathAccessDegraded</newvalue>
-            </mapping>
-            <mapping>
-               <value>16</value>
-               <newvalue>erasing</newvalue>
-            </mapping>
-            <mapping>
-               <value>17</value>
-               <newvalue>predictiveSpareRebuildReady</newvalue>
-            </mapping>
-            <mapping>
-               <value>18</value>
-               <newvalue>rapidParityInitInProgress</newvalue>
-            </mapping>
-            <mapping>
-               <value>19</value>
-               <newvalue>rapidParityInitPending</newvalue>
-            </mapping>
-            <mapping>
-               <value>20</value>
-               <newvalue>noAccessEncryptedNoCntlrKey</newvalue>
-            </mapping>
-            <mapping>
-               <value>21</value>
-               <newvalue>unencryptedToEncryptedInProgress</newvalue>
-            </mapping>
-            <mapping>
-               <value>22</value>
-               <newvalue>newLogDrvKeyRekeyInProgress</newvalue>
-            </mapping>
-            <mapping>
-               <value>23</value>
-               <newvalue>noAccessEncryptedCntlrEncryptnNotEnbld</newvalue>
-            </mapping>
-            <mapping>
-               <value>24</value>
-               <newvalue>unencryptedToEncryptedNotStarted</newvalue>
-            </mapping>
-            <mapping>
-               <value>25</value>
-               <newvalue>newLogDrvKeyRekeyRequestReceived</newvalue>
-            </mapping>
-         </mappings>
-      </value_map>
-   </value_maps>
+                            <applications>
+                                <application>
+                                    <name>Virtual Disks</name>
+                                </application>
+                            </applications>
+                            <preprocessing>
+                                <step>
+                                    <type>MULTIPLIER</type>
+                                    <params>1048576</params>
+                                </step>
+                            </preprocessing>
+                        </item_prototype>
+                        <item_prototype>
+                            <name>Disk {#SNMPINDEX}({#DISK_NAME}): Status</name>
+                            <type>SNMP_AGENT</type>
+                            <snmp_oid>1.3.6.1.4.1.232.3.2.3.1.1.4.{#SNMPINDEX}</snmp_oid>
+                            <key>system.hw.virtualdisk.status[cpqDaLogDrvStatus.{#SNMPINDEX}]</key>
+                            <delay>3m</delay>
+                            <history>2w</history>
+                            <description>Logical Drive Status.</description>
+                            <applications>
+                                <application>
+                                    <name>Virtual Disks</name>
+                                </application>
+                            </applications>
+                            <valuemap>
+                                <name>CPQIDA-MIB::cpqDaLogDrvStatus</name>
+                            </valuemap>
+                            <trigger_prototypes>
+                                <trigger_prototype>
+                                    <expression>{last()}=3</expression>
+                                    <recovery_mode>RECOVERY_EXPRESSION</recovery_mode>
+                                    <recovery_expression>{last()}&lt;&gt;3</recovery_expression>
+                                    <name>Disk {#SNMPINDEX}({#DISK_NAME}): Virtual disk failed</name>
+                                    <priority>HIGH</priority>
+                                    <description>Last value: {ITEM.LASTVALUE1}.&#13;
+Please check virtual disk for warnings or errors</description>
+                                </trigger_prototype>
+                                <trigger_prototype>
+                                    <expression>{last()}&gt;=4</expression>
+                                    <recovery_mode>RECOVERY_EXPRESSION</recovery_mode>
+                                    <recovery_expression>{last()}=1&#13;
+or&#13;
+{last()}=2</recovery_expression>
+                                    <name>Disk {#SNMPINDEX}({#DISK_NAME}): Virtual disk is not in OK state</name>
+                                    <priority>WARNING</priority>
+                                    <description>Last value: {ITEM.LASTVALUE1}.&#13;
+Please check virtual disk for warnings or errors</description>
+                                </trigger_prototype>
+                            </trigger_prototypes>
+                        </item_prototype>
+                    </item_prototypes>
+                </discovery_rule>
+            </discovery_rules>
+            <macros>
+                <macro>
+                    <macro>{$TEMP_WARN}</macro>
+                    <value>3</value>
+                </macro>
+            </macros>
+        </template>
+    </templates>
+    <graphs>
+        <graph>
+            <name>System: Power Meter</name>
+            <graph_items>
+                <graph_item>
+                    <drawtype>BOLD_LINE</drawtype>
+                    <color>43A047</color>
+                    <item>
+                        <host>Template Server HP iLO SNMPv2</host>
+                        <key>system.psu.meter.reading[cpqHePowerMeterCurrReading.0]</key>
+                    </item>
+                </graph_item>
+            </graph_items>
+        </graph>
+    </graphs>
+    <value_maps>
+        <value_map>
+            <name>CPQHLTH-MIB::cpqHeFltTolFanHotPlug</name>
+            <mappings>
+                <mapping>
+                    <value>1</value>
+                    <newvalue>other</newvalue>
+                </mapping>
+                <mapping>
+                    <value>2</value>
+                    <newvalue>nonHotPluggable</newvalue>
+                </mapping>
+                <mapping>
+                    <value>3</value>
+                    <newvalue>hotPluggable</newvalue>
+                </mapping>
+            </mappings>
+        </value_map>
+        <value_map>
+            <name>CPQHLTH-MIB::cpqHeFltTolFanRedundant</name>
+            <mappings>
+                <mapping>
+                    <value>1</value>
+                    <newvalue>other</newvalue>
+                </mapping>
+                <mapping>
+                    <value>2</value>
+                    <newvalue>notRedundant</newvalue>
+                </mapping>
+                <mapping>
+                    <value>3</value>
+                    <newvalue>redundant</newvalue>
+                </mapping>
+            </mappings>
+        </value_map>
+        <value_map>
+            <name>CPQHLTH-MIB::cpqHeFltTolFanType</name>
+            <mappings>
+                <mapping>
+                    <value>1</value>
+                    <newvalue>other</newvalue>
+                </mapping>
+                <mapping>
+                    <value>2</value>
+                    <newvalue>tachOutput</newvalue>
+                </mapping>
+                <mapping>
+                    <value>3</value>
+                    <newvalue>spinDetect</newvalue>
+                </mapping>
+            </mappings>
+        </value_map>
+        <value_map>
+            <name>CPQHLTH-MIB::cpqHeFltTolPowerSupplyCondition</name>
+            <mappings>
+                <mapping>
+                    <value>1</value>
+                    <newvalue>other</newvalue>
+                </mapping>
+                <mapping>
+                    <value>2</value>
+                    <newvalue>ok</newvalue>
+                </mapping>
+                <mapping>
+                    <value>3</value>
+                    <newvalue>degraded</newvalue>
+                </mapping>
+                <mapping>
+                    <value>4</value>
+                    <newvalue>failed</newvalue>
+                </mapping>
+            </mappings>
+        </value_map>
+        <value_map>
+            <name>CPQHLTH-MIB::cpqHeFltTolPowerSupplyErrorCondition</name>
+            <mappings>
+                <mapping>
+                    <value>1</value>
+                    <newvalue>noError</newvalue>
+                </mapping>
+                <mapping>
+                    <value>2</value>
+                    <newvalue>generalFailure</newvalue>
+                </mapping>
+                <mapping>
+                    <value>3</value>
+                    <newvalue>overvoltage</newvalue>
+                </mapping>
+                <mapping>
+                    <value>4</value>
+                    <newvalue>overcurrent</newvalue>
+                </mapping>
+                <mapping>
+                    <value>5</value>
+                    <newvalue>overtemperature</newvalue>
+                </mapping>
+                <mapping>
+                    <value>6</value>
+                    <newvalue>powerinputloss</newvalue>
+                </mapping>
+                <mapping>
+                    <value>7</value>
+                    <newvalue>fanfailure</newvalue>
+                </mapping>
+                <mapping>
+                    <value>8</value>
+                    <newvalue>vinhighwarning</newvalue>
+                </mapping>
+                <mapping>
+                    <value>9</value>
+                    <newvalue>vinlowwarning</newvalue>
+                </mapping>
+                <mapping>
+                    <value>10</value>
+                    <newvalue>vouthighwarning</newvalue>
+                </mapping>
+                <mapping>
+                    <value>11</value>
+                    <newvalue>voutlowwarning</newvalue>
+                </mapping>
+                <mapping>
+                    <value>12</value>
+                    <newvalue>inlettemphighwarning</newvalue>
+                </mapping>
+                <mapping>
+                    <value>13</value>
+                    <newvalue>internaltemphighwarning</newvalue>
+                </mapping>
+                <mapping>
+                    <value>14</value>
+                    <newvalue>vauxhighwarning</newvalue>
+                </mapping>
+                <mapping>
+                    <value>15</value>
+                    <newvalue>vauxlowwarning</newvalue>
+                </mapping>
+            </mappings>
+        </value_map>
+        <value_map>
+            <name>CPQHLTH-MIB::cpqHeFltTolPowerSupplyHotPlug</name>
+            <mappings>
+                <mapping>
+                    <value>1</value>
+                    <newvalue>other</newvalue>
+                </mapping>
+                <mapping>
+                    <value>2</value>
+                    <newvalue>nonHotPluggable</newvalue>
+                </mapping>
+                <mapping>
+                    <value>3</value>
+                    <newvalue>hotPluggable</newvalue>
+                </mapping>
+            </mappings>
+        </value_map>
+        <value_map>
+            <name>CPQHLTH-MIB::cpqHeFltTolPowerSupplyPresent</name>
+            <mappings>
+                <mapping>
+                    <value>1</value>
+                    <newvalue>other</newvalue>
+                </mapping>
+                <mapping>
+                    <value>2</value>
+                    <newvalue>absent</newvalue>
+                </mapping>
+                <mapping>
+                    <value>3</value>
+                    <newvalue>present</newvalue>
+                </mapping>
+            </mappings>
+        </value_map>
+        <value_map>
+            <name>CPQHLTH-MIB::cpqHeFltTolPowerSupplyRedundant</name>
+            <mappings>
+                <mapping>
+                    <value>1</value>
+                    <newvalue>other</newvalue>
+                </mapping>
+                <mapping>
+                    <value>2</value>
+                    <newvalue>notRedundant</newvalue>
+                </mapping>
+                <mapping>
+                    <value>3</value>
+                    <newvalue>redundant</newvalue>
+                </mapping>
+            </mappings>
+        </value_map>
+        <value_map>
+            <name>CPQHLTH-MIB::cpqHeFltTolPowerSupplyStatus</name>
+            <mappings>
+                <mapping>
+                    <value>1</value>
+                    <newvalue>noError</newvalue>
+                </mapping>
+                <mapping>
+                    <value>2</value>
+                    <newvalue>generalFailure</newvalue>
+                </mapping>
+                <mapping>
+                    <value>3</value>
+                    <newvalue>bistFailure</newvalue>
+                </mapping>
+                <mapping>
+                    <value>4</value>
+                    <newvalue>fanFailure</newvalue>
+                </mapping>
+                <mapping>
+                    <value>5</value>
+                    <newvalue>tempFailure</newvalue>
+                </mapping>
+                <mapping>
+                    <value>6</value>
+                    <newvalue>interlockOpen</newvalue>
+                </mapping>
+                <mapping>
+                    <value>7</value>
+                    <newvalue>epromFailed</newvalue>
+                </mapping>
+                <mapping>
+                    <value>8</value>
+                    <newvalue>vrefFailed</newvalue>
+                </mapping>
+                <mapping>
+                    <value>9</value>
+                    <newvalue>dacFailed</newvalue>
+                </mapping>
+                <mapping>
+                    <value>10</value>
+                    <newvalue>ramTestFailed</newvalue>
+                </mapping>
+                <mapping>
+                    <value>11</value>
+                    <newvalue>voltageChannelFailed</newvalue>
+                </mapping>
+                <mapping>
+                    <value>12</value>
+                    <newvalue>orringdiodeFailed</newvalue>
+                </mapping>
+                <mapping>
+                    <value>13</value>
+                    <newvalue>brownOut</newvalue>
+                </mapping>
+                <mapping>
+                    <value>14</value>
+                    <newvalue>giveupOnStartup</newvalue>
+                </mapping>
+                <mapping>
+                    <value>15</value>
+                    <newvalue>nvramInvalid</newvalue>
+                </mapping>
+                <mapping>
+                    <value>16</value>
+                    <newvalue>calibrationTableInvalid</newvalue>
+                </mapping>
+            </mappings>
+        </value_map>
+        <value_map>
+            <name>CPQHLTH-MIB::cpqHePowerMeterStatus</name>
+            <mappings>
+                <mapping>
+                    <value>1</value>
+                    <newvalue>other</newvalue>
+                </mapping>
+                <mapping>
+                    <value>2</value>
+                    <newvalue>present</newvalue>
+                </mapping>
+                <mapping>
+                    <value>3</value>
+                    <newvalue>absent</newvalue>
+                </mapping>
+            </mappings>
+        </value_map>
+        <value_map>
+            <name>CPQHLTH-MIB::cpqHePowerMeterSupport</name>
+            <mappings>
+                <mapping>
+                    <value>1</value>
+                    <newvalue>other</newvalue>
+                </mapping>
+                <mapping>
+                    <value>2</value>
+                    <newvalue>supported</newvalue>
+                </mapping>
+                <mapping>
+                    <value>3</value>
+                    <newvalue>unsupported</newvalue>
+                </mapping>
+            </mappings>
+        </value_map>
+        <value_map>
+            <name>CPQHLTH-MIB::cpqHeResilientMemCondition</name>
+            <mappings>
+                <mapping>
+                    <value>1</value>
+                    <newvalue>other</newvalue>
+                </mapping>
+                <mapping>
+                    <value>2</value>
+                    <newvalue>ok</newvalue>
+                </mapping>
+                <mapping>
+                    <value>3</value>
+                    <newvalue>degraded</newvalue>
+                </mapping>
+            </mappings>
+        </value_map>
+        <value_map>
+            <name>CPQHLTH-MIB::cpqHeResilientMemStatus</name>
+            <mappings>
+                <mapping>
+                    <value>1</value>
+                    <newvalue>other</newvalue>
+                </mapping>
+                <mapping>
+                    <value>2</value>
+                    <newvalue>notProtected</newvalue>
+                </mapping>
+                <mapping>
+                    <value>3</value>
+                    <newvalue>protected</newvalue>
+                </mapping>
+                <mapping>
+                    <value>4</value>
+                    <newvalue>degraded</newvalue>
+                </mapping>
+                <mapping>
+                    <value>5</value>
+                    <newvalue>dimmECC</newvalue>
+                </mapping>
+                <mapping>
+                    <value>6</value>
+                    <newvalue>mirrorNoFaults</newvalue>
+                </mapping>
+                <mapping>
+                    <value>7</value>
+                    <newvalue>mirrorWithFaults</newvalue>
+                </mapping>
+                <mapping>
+                    <value>8</value>
+                    <newvalue>hotSpareNoFaults</newvalue>
+                </mapping>
+                <mapping>
+                    <value>9</value>
+                    <newvalue>hotSpareWithFaults</newvalue>
+                </mapping>
+                <mapping>
+                    <value>10</value>
+                    <newvalue>xorNoFaults</newvalue>
+                </mapping>
+                <mapping>
+                    <value>11</value>
+                    <newvalue>xorWithFaults</newvalue>
+                </mapping>
+                <mapping>
+                    <value>12</value>
+                    <newvalue>advancedECC</newvalue>
+                </mapping>
+                <mapping>
+                    <value>13</value>
+                    <newvalue>advancedECCWithFaults</newvalue>
+                </mapping>
+                <mapping>
+                    <value>14</value>
+                    <newvalue>lockStep</newvalue>
+                </mapping>
+                <mapping>
+                    <value>15</value>
+                    <newvalue>lockStepWithFaults</newvalue>
+                </mapping>
+            </mappings>
+        </value_map>
+        <value_map>
+            <name>CPQHLTH-MIB::cpqHeResilientMemTypeActive</name>
+            <mappings>
+                <mapping>
+                    <value>1</value>
+                    <newvalue>other</newvalue>
+                </mapping>
+                <mapping>
+                    <value>2</value>
+                    <newvalue>none</newvalue>
+                </mapping>
+                <mapping>
+                    <value>3</value>
+                    <newvalue>onLineSpare</newvalue>
+                </mapping>
+                <mapping>
+                    <value>4</value>
+                    <newvalue>mirrored</newvalue>
+                </mapping>
+                <mapping>
+                    <value>5</value>
+                    <newvalue>advancedECC</newvalue>
+                </mapping>
+            </mappings>
+        </value_map>
+        <value_map>
+            <name>CPQHLTH-MIB::cpqHeResMem2ModuleCondition</name>
+            <mappings>
+                <mapping>
+                    <value>1</value>
+                    <newvalue>other</newvalue>
+                </mapping>
+                <mapping>
+                    <value>2</value>
+                    <newvalue>ok</newvalue>
+                </mapping>
+                <mapping>
+                    <value>3</value>
+                    <newvalue>degraded</newvalue>
+                </mapping>
+                <mapping>
+                    <value>4</value>
+                    <newvalue>degradedModuleIndexUnknown</newvalue>
+                </mapping>
+            </mappings>
+        </value_map>
+        <value_map>
+            <name>CPQHLTH-MIB::cpqHeResMem2ModuleSmartMemory</name>
+            <mappings>
+                <mapping>
+                    <value>1</value>
+                    <newvalue>other</newvalue>
+                </mapping>
+                <mapping>
+                    <value>2</value>
+                    <newvalue>notHPSmartMemory</newvalue>
+                </mapping>
+                <mapping>
+                    <value>3</value>
+                    <newvalue>isHPSmartMemory</newvalue>
+                </mapping>
+            </mappings>
+        </value_map>
+        <value_map>
+            <name>CPQHLTH-MIB::cpqHeResMem2ModuleStatus</name>
+            <mappings>
+                <mapping>
+                    <value>1</value>
+                    <newvalue>other</newvalue>
+                </mapping>
+                <mapping>
+                    <value>2</value>
+                    <newvalue>notPresent</newvalue>
+                </mapping>
+                <mapping>
+                    <value>3</value>
+                    <newvalue>present</newvalue>
+                </mapping>
+                <mapping>
+                    <value>4</value>
+                    <newvalue>good</newvalue>
+                </mapping>
+                <mapping>
+                    <value>5</value>
+                    <newvalue>add</newvalue>
+                </mapping>
+                <mapping>
+                    <value>6</value>
+                    <newvalue>upgrade</newvalue>
+                </mapping>
+                <mapping>
+                    <value>7</value>
+                    <newvalue>missing</newvalue>
+                </mapping>
+                <mapping>
+                    <value>8</value>
+                    <newvalue>doesNotMatch</newvalue>
+                </mapping>
+                <mapping>
+                    <value>9</value>
+                    <newvalue>notSupported</newvalue>
+                </mapping>
+                <mapping>
+                    <value>10</value>
+                    <newvalue>badConfig</newvalue>
+                </mapping>
+                <mapping>
+                    <value>11</value>
+                    <newvalue>degraded</newvalue>
+                </mapping>
+                <mapping>
+                    <value>12</value>
+                    <newvalue>spare</newvalue>
+                </mapping>
+                <mapping>
+                    <value>13</value>
+                    <newvalue>partial</newvalue>
+                </mapping>
+            </mappings>
+        </value_map>
+        <value_map>
+            <name>CPQHLTH-MIB::cpqHeTemperatureLocale</name>
+            <mappings>
+                <mapping>
+                    <value>1</value>
+                    <newvalue>other</newvalue>
+                </mapping>
+                <mapping>
+                    <value>2</value>
+                    <newvalue>unknown</newvalue>
+                </mapping>
+                <mapping>
+                    <value>3</value>
+                    <newvalue>system</newvalue>
+                </mapping>
+                <mapping>
+                    <value>4</value>
+                    <newvalue>systemBoard</newvalue>
+                </mapping>
+                <mapping>
+                    <value>5</value>
+                    <newvalue>ioBoard</newvalue>
+                </mapping>
+                <mapping>
+                    <value>6</value>
+                    <newvalue>cpu</newvalue>
+                </mapping>
+                <mapping>
+                    <value>7</value>
+                    <newvalue>memory</newvalue>
+                </mapping>
+                <mapping>
+                    <value>8</value>
+                    <newvalue>storage</newvalue>
+                </mapping>
+                <mapping>
+                    <value>9</value>
+                    <newvalue>removableMedia</newvalue>
+                </mapping>
+                <mapping>
+                    <value>10</value>
+                    <newvalue>powerSupply</newvalue>
+                </mapping>
+                <mapping>
+                    <value>11</value>
+                    <newvalue>ambient</newvalue>
+                </mapping>
+                <mapping>
+                    <value>12</value>
+                    <newvalue>chassis</newvalue>
+                </mapping>
+                <mapping>
+                    <value>13</value>
+                    <newvalue>bridgeCard</newvalue>
+                </mapping>
+            </mappings>
+        </value_map>
+        <value_map>
+            <name>CPQHOST-MIB::cpqHoFwVerDeviceType</name>
+            <mappings>
+                <mapping>
+                    <value>1</value>
+                    <newvalue>other</newvalue>
+                </mapping>
+                <mapping>
+                    <value>2</value>
+                    <newvalue>internalArrayController</newvalue>
+                </mapping>
+                <mapping>
+                    <value>3</value>
+                    <newvalue>fibreArrayController</newvalue>
+                </mapping>
+                <mapping>
+                    <value>4</value>
+                    <newvalue>scsiController</newvalue>
+                </mapping>
+                <mapping>
+                    <value>5</value>
+                    <newvalue>fibreChannelTapeController</newvalue>
+                </mapping>
+                <mapping>
+                    <value>6</value>
+                    <newvalue>modularDataRouter</newvalue>
+                </mapping>
+                <mapping>
+                    <value>7</value>
+                    <newvalue>ideCdRomDrive</newvalue>
+                </mapping>
+                <mapping>
+                    <value>8</value>
+                    <newvalue>ideDiskDrive</newvalue>
+                </mapping>
+                <mapping>
+                    <value>9</value>
+                    <newvalue>scsiCdRom-ScsiAttached</newvalue>
+                </mapping>
+                <mapping>
+                    <value>10</value>
+                    <newvalue>scsiDiskDrive-ScsiAttached</newvalue>
+                </mapping>
+                <mapping>
+                    <value>11</value>
+                    <newvalue>scsiTapeDrive-ScsiAttached</newvalue>
+                </mapping>
+                <mapping>
+                    <value>12</value>
+                    <newvalue>scsiTapeLibrary-ScsiAttached</newvalue>
+                </mapping>
+                <mapping>
+                    <value>13</value>
+                    <newvalue>scsiDiskDrive-ArrayAttached</newvalue>
+                </mapping>
+                <mapping>
+                    <value>14</value>
+                    <newvalue>scsiTapeDrive-ArrayAttached</newvalue>
+                </mapping>
+                <mapping>
+                    <value>15</value>
+                    <newvalue>scsiTapeLibrary-ArrayAttached</newvalue>
+                </mapping>
+                <mapping>
+                    <value>16</value>
+                    <newvalue>scsiDiskDrive-FibreAttached</newvalue>
+                </mapping>
+                <mapping>
+                    <value>17</value>
+                    <newvalue>scsiTapeDrive-FibreAttached</newvalue>
+                </mapping>
+                <mapping>
+                    <value>18</value>
+                    <newvalue>scsiTapeLibrary-FibreAttached</newvalue>
+                </mapping>
+                <mapping>
+                    <value>19</value>
+                    <newvalue>scsiEnclosureBackplaneRom-ScsiAttached</newvalue>
+                </mapping>
+                <mapping>
+                    <value>20</value>
+                    <newvalue>scsiEnclosureBackplaneRom-ArrayAttached</newvalue>
+                </mapping>
+                <mapping>
+                    <value>21</value>
+                    <newvalue>scsiEnclosureBackplaneRom-FibreAttached</newvalue>
+                </mapping>
+                <mapping>
+                    <value>22</value>
+                    <newvalue>scsiEnclosureBackplaneRom-ra4x00</newvalue>
+                </mapping>
+                <mapping>
+                    <value>23</value>
+                    <newvalue>systemRom</newvalue>
+                </mapping>
+                <mapping>
+                    <value>24</value>
+                    <newvalue>networkInterfaceController</newvalue>
+                </mapping>
+                <mapping>
+                    <value>25</value>
+                    <newvalue>remoteInsightBoard</newvalue>
+                </mapping>
+            </mappings>
+        </value_map>
+        <value_map>
+            <name>CPQHOST-MIB::cpqHoFwVerUpdateMethod</name>
+            <mappings>
+                <mapping>
+                    <value>1</value>
+                    <newvalue>other</newvalue>
+                </mapping>
+                <mapping>
+                    <value>2</value>
+                    <newvalue>noUpdate</newvalue>
+                </mapping>
+                <mapping>
+                    <value>3</value>
+                    <newvalue>softwareflash</newvalue>
+                </mapping>
+                <mapping>
+                    <value>4</value>
+                    <newvalue>replacePhysicalRom</newvalue>
+                </mapping>
+            </mappings>
+        </value_map>
+        <value_map>
+            <name>CPQHOST-MIB::cpqHoOsType</name>
+            <mappings>
+                <mapping>
+                    <value>1</value>
+                    <newvalue>other</newvalue>
+                </mapping>
+                <mapping>
+                    <value>2</value>
+                    <newvalue>netware</newvalue>
+                </mapping>
+                <mapping>
+                    <value>3</value>
+                    <newvalue>windowsnt</newvalue>
+                </mapping>
+                <mapping>
+                    <value>4</value>
+                    <newvalue>sco-unix</newvalue>
+                </mapping>
+                <mapping>
+                    <value>5</value>
+                    <newvalue>unixware</newvalue>
+                </mapping>
+                <mapping>
+                    <value>11</value>
+                    <newvalue>open-vms</newvalue>
+                </mapping>
+                <mapping>
+                    <value>14</value>
+                    <newvalue>linux</newvalue>
+                </mapping>
+                <mapping>
+                    <value>16</value>
+                    <newvalue>tru64UNIX</newvalue>
+                </mapping>
+                <mapping>
+                    <value>21</value>
+                    <newvalue>windows2008</newvalue>
+                </mapping>
+                <mapping>
+                    <value>22</value>
+                    <newvalue>windows2008-x64</newvalue>
+                </mapping>
+                <mapping>
+                    <value>23</value>
+                    <newvalue>windows2008-ia64</newvalue>
+                </mapping>
+                <mapping>
+                    <value>24</value>
+                    <newvalue>vmware-esx</newvalue>
+                </mapping>
+                <mapping>
+                    <value>25</value>
+                    <newvalue>vmware-esxi</newvalue>
+                </mapping>
+                <mapping>
+                    <value>26</value>
+                    <newvalue>windows2012</newvalue>
+                </mapping>
+                <mapping>
+                    <value>37</value>
+                    <newvalue>windows2008-r2</newvalue>
+                </mapping>
+                <mapping>
+                    <value>38</value>
+                    <newvalue>windows2012-r2</newvalue>
+                </mapping>
+                <mapping>
+                    <value>39</value>
+                    <newvalue>rhel</newvalue>
+                </mapping>
+                <mapping>
+                    <value>40</value>
+                    <newvalue>rhel-64</newvalue>
+                </mapping>
+                <mapping>
+                    <value>42</value>
+                    <newvalue>sles</newvalue>
+                </mapping>
+                <mapping>
+                    <value>43</value>
+                    <newvalue>sles-64</newvalue>
+                </mapping>
+                <mapping>
+                    <value>44</value>
+                    <newvalue>ubuntu</newvalue>
+                </mapping>
+                <mapping>
+                    <value>45</value>
+                    <newvalue>ubuntu-64</newvalue>
+                </mapping>
+                <mapping>
+                    <value>46</value>
+                    <newvalue>debian</newvalue>
+                </mapping>
+                <mapping>
+                    <value>47</value>
+                    <newvalue>debian-64</newvalue>
+                </mapping>
+                <mapping>
+                    <value>48</value>
+                    <newvalue>linux-64-bit</newvalue>
+                </mapping>
+                <mapping>
+                    <value>49</value>
+                    <newvalue>other-64-bit</newvalue>
+                </mapping>
+                <mapping>
+                    <value>50</value>
+                    <newvalue>centos-32bit</newvalue>
+                </mapping>
+                <mapping>
+                    <value>51</value>
+                    <newvalue>centos-64bit</newvalue>
+                </mapping>
+                <mapping>
+                    <value>52</value>
+                    <newvalue>oracle-linux32</newvalue>
+                </mapping>
+                <mapping>
+                    <value>53</value>
+                    <newvalue>oracle-linux64</newvalue>
+                </mapping>
+                <mapping>
+                    <value>54</value>
+                    <newvalue>apple-osx</newvalue>
+                </mapping>
+                <mapping>
+                    <value>55</value>
+                    <newvalue>windows2016</newvalue>
+                </mapping>
+                <mapping>
+                    <value>56</value>
+                    <newvalue>nanoserver</newvalue>
+                </mapping>
+            </mappings>
+        </value_map>
+        <value_map>
+            <name>CPQIDA-MIB::cpqDaAccelBattery</name>
+            <mappings>
+                <mapping>
+                    <value>1</value>
+                    <newvalue>other</newvalue>
+                </mapping>
+                <mapping>
+                    <value>2</value>
+                    <newvalue>ok</newvalue>
+                </mapping>
+                <mapping>
+                    <value>3</value>
+                    <newvalue>recharging</newvalue>
+                </mapping>
+                <mapping>
+                    <value>4</value>
+                    <newvalue>failed</newvalue>
+                </mapping>
+                <mapping>
+                    <value>5</value>
+                    <newvalue>degraded</newvalue>
+                </mapping>
+                <mapping>
+                    <value>6</value>
+                    <newvalue>notPresent</newvalue>
+                </mapping>
+                <mapping>
+                    <value>7</value>
+                    <newvalue>capacitorFailed</newvalue>
+                </mapping>
+            </mappings>
+        </value_map>
+        <value_map>
+            <name>CPQIDA-MIB::cpqDaAccelStatus</name>
+            <mappings>
+                <mapping>
+                    <value>1</value>
+                    <newvalue>other</newvalue>
+                </mapping>
+                <mapping>
+                    <value>2</value>
+                    <newvalue>invalid</newvalue>
+                </mapping>
+                <mapping>
+                    <value>3</value>
+                    <newvalue>enabled</newvalue>
+                </mapping>
+                <mapping>
+                    <value>4</value>
+                    <newvalue>tmpDisabled</newvalue>
+                </mapping>
+                <mapping>
+                    <value>5</value>
+                    <newvalue>permDisabled</newvalue>
+                </mapping>
+                <mapping>
+                    <value>6</value>
+                    <newvalue>cacheModFlashMemNotAttached</newvalue>
+                </mapping>
+                <mapping>
+                    <value>7</value>
+                    <newvalue>cacheModDegradedFailsafeSpeed</newvalue>
+                </mapping>
+                <mapping>
+                    <value>8</value>
+                    <newvalue>cacheModCriticalFailure</newvalue>
+                </mapping>
+                <mapping>
+                    <value>9</value>
+                    <newvalue>cacheReadCacheNotMapped</newvalue>
+                </mapping>
+            </mappings>
+        </value_map>
+        <value_map>
+            <name>CPQIDA-MIB::cpqDaCntlrModel</name>
+            <mappings>
+                <mapping>
+                    <value>1</value>
+                    <newvalue>other</newvalue>
+                </mapping>
+                <mapping>
+                    <value>2</value>
+                    <newvalue>ida</newvalue>
+                </mapping>
+                <mapping>
+                    <value>3</value>
+                    <newvalue>idaExpansion</newvalue>
+                </mapping>
+                <mapping>
+                    <value>4</value>
+                    <newvalue>ida-2</newvalue>
+                </mapping>
+                <mapping>
+                    <value>5</value>
+                    <newvalue>smart</newvalue>
+                </mapping>
+                <mapping>
+                    <value>6</value>
+                    <newvalue>smart-2e</newvalue>
+                </mapping>
+                <mapping>
+                    <value>7</value>
+                    <newvalue>smart-2p</newvalue>
+                </mapping>
+                <mapping>
+                    <value>8</value>
+                    <newvalue>smart-2sl</newvalue>
+                </mapping>
+                <mapping>
+                    <value>9</value>
+                    <newvalue>smart-3100es</newvalue>
+                </mapping>
+                <mapping>
+                    <value>10</value>
+                    <newvalue>smart-3200</newvalue>
+                </mapping>
+                <mapping>
+                    <value>11</value>
+                    <newvalue>smart-2dh</newvalue>
+                </mapping>
+                <mapping>
+                    <value>12</value>
+                    <newvalue>smart-221</newvalue>
+                </mapping>
+                <mapping>
+                    <value>13</value>
+                    <newvalue>sa-4250es</newvalue>
+                </mapping>
+                <mapping>
+                    <value>14</value>
+                    <newvalue>sa-4200</newvalue>
+                </mapping>
+                <mapping>
+                    <value>15</value>
+                    <newvalue>sa-integrated</newvalue>
+                </mapping>
+                <mapping>
+                    <value>16</value>
+                    <newvalue>sa-431</newvalue>
+                </mapping>
+                <mapping>
+                    <value>17</value>
+                    <newvalue>sa-5300</newvalue>
+                </mapping>
+                <mapping>
+                    <value>18</value>
+                    <newvalue>raidLc2</newvalue>
+                </mapping>
+                <mapping>
+                    <value>19</value>
+                    <newvalue>sa-5i</newvalue>
+                </mapping>
+                <mapping>
+                    <value>20</value>
+                    <newvalue>sa-532</newvalue>
+                </mapping>
+                <mapping>
+                    <value>21</value>
+                    <newvalue>sa-5312</newvalue>
+                </mapping>
+                <mapping>
+                    <value>22</value>
+                    <newvalue>sa-641</newvalue>
+                </mapping>
+                <mapping>
+                    <value>23</value>
+                    <newvalue>sa-642</newvalue>
+                </mapping>
+                <mapping>
+                    <value>24</value>
+                    <newvalue>sa-6400</newvalue>
+                </mapping>
+                <mapping>
+                    <value>25</value>
+                    <newvalue>sa-6400em</newvalue>
+                </mapping>
+                <mapping>
+                    <value>26</value>
+                    <newvalue>sa-6i</newvalue>
+                </mapping>
+                <mapping>
+                    <value>27</value>
+                    <newvalue>sa-generic</newvalue>
+                </mapping>
+                <mapping>
+                    <value>29</value>
+                    <newvalue>sa-p600</newvalue>
+                </mapping>
+                <mapping>
+                    <value>30</value>
+                    <newvalue>sa-p400</newvalue>
+                </mapping>
+                <mapping>
+                    <value>31</value>
+                    <newvalue>sa-e200</newvalue>
+                </mapping>
+                <mapping>
+                    <value>32</value>
+                    <newvalue>sa-e200i</newvalue>
+                </mapping>
+                <mapping>
+                    <value>33</value>
+                    <newvalue>sa-p400i</newvalue>
+                </mapping>
+                <mapping>
+                    <value>34</value>
+                    <newvalue>sa-p800</newvalue>
+                </mapping>
+                <mapping>
+                    <value>35</value>
+                    <newvalue>sa-e500</newvalue>
+                </mapping>
+                <mapping>
+                    <value>36</value>
+                    <newvalue>sa-p700m</newvalue>
+                </mapping>
+                <mapping>
+                    <value>37</value>
+                    <newvalue>sa-p212</newvalue>
+                </mapping>
+                <mapping>
+                    <value>38</value>
+                    <newvalue>sa-p410</newvalue>
+                </mapping>
+                <mapping>
+                    <value>39</value>
+                    <newvalue>sa-p410i</newvalue>
+                </mapping>
+                <mapping>
+                    <value>40</value>
+                    <newvalue>sa-p411</newvalue>
+                </mapping>
+                <mapping>
+                    <value>41</value>
+                    <newvalue>sa-b110i</newvalue>
+                </mapping>
+                <mapping>
+                    <value>42</value>
+                    <newvalue>sa-p712m</newvalue>
+                </mapping>
+                <mapping>
+                    <value>43</value>
+                    <newvalue>sa-p711m</newvalue>
+                </mapping>
+                <mapping>
+                    <value>44</value>
+                    <newvalue>sa-p812</newvalue>
+                </mapping>
+                <mapping>
+                    <value>45</value>
+                    <newvalue>sw-1210m</newvalue>
+                </mapping>
+                <mapping>
+                    <value>46</value>
+                    <newvalue>sa-p220i</newvalue>
+                </mapping>
+                <mapping>
+                    <value>47</value>
+                    <newvalue>sa-p222</newvalue>
+                </mapping>
+                <mapping>
+                    <value>48</value>
+                    <newvalue>sa-p420</newvalue>
+                </mapping>
+                <mapping>
+                    <value>49</value>
+                    <newvalue>sa-p420i</newvalue>
+                </mapping>
+                <mapping>
+                    <value>50</value>
+                    <newvalue>sa-p421</newvalue>
+                </mapping>
+                <mapping>
+                    <value>51</value>
+                    <newvalue>sa-b320i</newvalue>
+                </mapping>
+                <mapping>
+                    <value>52</value>
+                    <newvalue>sa-p822</newvalue>
+                </mapping>
+                <mapping>
+                    <value>53</value>
+                    <newvalue>sa-p721m</newvalue>
+                </mapping>
+                <mapping>
+                    <value>54</value>
+                    <newvalue>sa-b120i</newvalue>
+                </mapping>
+                <mapping>
+                    <value>55</value>
+                    <newvalue>hps-1224</newvalue>
+                </mapping>
+                <mapping>
+                    <value>56</value>
+                    <newvalue>hps-1228</newvalue>
+                </mapping>
+                <mapping>
+                    <value>57</value>
+                    <newvalue>hps-1228m</newvalue>
+                </mapping>
+                <mapping>
+                    <value>58</value>
+                    <newvalue>sa-p822se</newvalue>
+                </mapping>
+                <mapping>
+                    <value>59</value>
+                    <newvalue>hps-1224e</newvalue>
+                </mapping>
+                <mapping>
+                    <value>60</value>
+                    <newvalue>hps-1228e</newvalue>
+                </mapping>
+                <mapping>
+                    <value>61</value>
+                    <newvalue>hps-1228em</newvalue>
+                </mapping>
+                <mapping>
+                    <value>62</value>
+                    <newvalue>sa-p230i</newvalue>
+                </mapping>
+                <mapping>
+                    <value>63</value>
+                    <newvalue>sa-p430i</newvalue>
+                </mapping>
+                <mapping>
+                    <value>64</value>
+                    <newvalue>sa-p430</newvalue>
+                </mapping>
+                <mapping>
+                    <value>65</value>
+                    <newvalue>sa-p431</newvalue>
+                </mapping>
+                <mapping>
+                    <value>66</value>
+                    <newvalue>sa-p731m</newvalue>
+                </mapping>
+                <mapping>
+                    <value>67</value>
+                    <newvalue>sa-p830i</newvalue>
+                </mapping>
+                <mapping>
+                    <value>68</value>
+                    <newvalue>sa-p830</newvalue>
+                </mapping>
+                <mapping>
+                    <value>69</value>
+                    <newvalue>sa-p831</newvalue>
+                </mapping>
+                <mapping>
+                    <value>70</value>
+                    <newvalue>sa-p530</newvalue>
+                </mapping>
+                <mapping>
+                    <value>71</value>
+                    <newvalue>sa-p531</newvalue>
+                </mapping>
+                <mapping>
+                    <value>72</value>
+                    <newvalue>sa-p244br</newvalue>
+                </mapping>
+                <mapping>
+                    <value>73</value>
+                    <newvalue>sa-p246br</newvalue>
+                </mapping>
+                <mapping>
+                    <value>74</value>
+                    <newvalue>sa-p440</newvalue>
+                </mapping>
+                <mapping>
+                    <value>75</value>
+                    <newvalue>sa-p440ar</newvalue>
+                </mapping>
+                <mapping>
+                    <value>76</value>
+                    <newvalue>sa-p441</newvalue>
+                </mapping>
+                <mapping>
+                    <value>77</value>
+                    <newvalue>sa-p741m</newvalue>
+                </mapping>
+                <mapping>
+                    <value>78</value>
+                    <newvalue>sa-p840</newvalue>
+                </mapping>
+                <mapping>
+                    <value>79</value>
+                    <newvalue>sa-p841</newvalue>
+                </mapping>
+                <mapping>
+                    <value>80</value>
+                    <newvalue>sh-h240ar</newvalue>
+                </mapping>
+                <mapping>
+                    <value>81</value>
+                    <newvalue>sh-h244br</newvalue>
+                </mapping>
+                <mapping>
+                    <value>82</value>
+                    <newvalue>sh-h240</newvalue>
+                </mapping>
+                <mapping>
+                    <value>83</value>
+                    <newvalue>sh-h241</newvalue>
+                </mapping>
+                <mapping>
+                    <value>84</value>
+                    <newvalue>sa-b140i</newvalue>
+                </mapping>
+                <mapping>
+                    <value>85</value>
+                    <newvalue>sh-generic</newvalue>
+                </mapping>
+                <mapping>
+                    <value>88</value>
+                    <newvalue>sa-p840ar</newvalue>
+                </mapping>
+                <mapping>
+                    <value>89</value>
+                    <newvalue>sa-p542d</newvalue>
+                </mapping>
+                <mapping>
+                    <value>90</value>
+                    <newvalue>s100i</newvalue>
+                </mapping>
+                <mapping>
+                    <value>91</value>
+                    <newvalue>e208i-p</newvalue>
+                </mapping>
+                <mapping>
+                    <value>92</value>
+                    <newvalue>e208i-a</newvalue>
+                </mapping>
+                <mapping>
+                    <value>93</value>
+                    <newvalue>e208i-c</newvalue>
+                </mapping>
+                <mapping>
+                    <value>94</value>
+                    <newvalue>e208e-p</newvalue>
+                </mapping>
+                <mapping>
+                    <value>95</value>
+                    <newvalue>p204i-b</newvalue>
+                </mapping>
+                <mapping>
+                    <value>96</value>
+                    <newvalue>p204i-c</newvalue>
+                </mapping>
+                <mapping>
+                    <value>97</value>
+                    <newvalue>p408i-p</newvalue>
+                </mapping>
+                <mapping>
+                    <value>98</value>
+                    <newvalue>p408i-a</newvalue>
+                </mapping>
+                <mapping>
+                    <value>99</value>
+                    <newvalue>p408e-p</newvalue>
+                </mapping>
+                <mapping>
+                    <value>100</value>
+                    <newvalue>p408i-c</newvalue>
+                </mapping>
+                <mapping>
+                    <value>101</value>
+                    <newvalue>p408e-m</newvalue>
+                </mapping>
+                <mapping>
+                    <value>102</value>
+                    <newvalue>p416ie-m</newvalue>
+                </mapping>
+                <mapping>
+                    <value>103</value>
+                    <newvalue>p816i-a</newvalue>
+                </mapping>
+                <mapping>
+                    <value>104</value>
+                    <newvalue>p408i-sb</newvalue>
+                </mapping>
+            </mappings>
+        </value_map>
+        <value_map>
+            <name>CPQIDA-MIB::cpqDaLogDrvFaultTol</name>
+            <mappings>
+                <mapping>
+                    <value>0</value>
+                    <newvalue>other</newvalue>
+                </mapping>
+                <mapping>
+                    <value>2</value>
+                    <newvalue>none</newvalue>
+                </mapping>
+                <mapping>
+                    <value>3</value>
+                    <newvalue>RAID-1/RAID-10</newvalue>
+                </mapping>
+                <mapping>
+                    <value>4</value>
+                    <newvalue>RAID-4</newvalue>
+                </mapping>
+                <mapping>
+                    <value>5</value>
+                    <newvalue>RAID-5</newvalue>
+                </mapping>
+                <mapping>
+                    <value>7</value>
+                    <newvalue>RAID-6</newvalue>
+                </mapping>
+                <mapping>
+                    <value>8</value>
+                    <newvalue>RAID-50</newvalue>
+                </mapping>
+                <mapping>
+                    <value>9</value>
+                    <newvalue>RAID-60</newvalue>
+                </mapping>
+                <mapping>
+                    <value>10</value>
+                    <newvalue>RAID-1 ADM</newvalue>
+                </mapping>
+                <mapping>
+                    <value>11</value>
+                    <newvalue>RAID-10 ADM</newvalue>
+                </mapping>
+            </mappings>
+        </value_map>
+        <value_map>
+            <name>CPQIDA-MIB::cpqDaLogDrvStatus</name>
+            <mappings>
+                <mapping>
+                    <value>1</value>
+                    <newvalue>other</newvalue>
+                </mapping>
+                <mapping>
+                    <value>2</value>
+                    <newvalue>ok</newvalue>
+                </mapping>
+                <mapping>
+                    <value>3</value>
+                    <newvalue>failed</newvalue>
+                </mapping>
+                <mapping>
+                    <value>4</value>
+                    <newvalue>unconfigured</newvalue>
+                </mapping>
+                <mapping>
+                    <value>5</value>
+                    <newvalue>recovering</newvalue>
+                </mapping>
+                <mapping>
+                    <value>6</value>
+                    <newvalue>readyForRebuild</newvalue>
+                </mapping>
+                <mapping>
+                    <value>7</value>
+                    <newvalue>rebuilding</newvalue>
+                </mapping>
+                <mapping>
+                    <value>8</value>
+                    <newvalue>wrongDrive</newvalue>
+                </mapping>
+                <mapping>
+                    <value>9</value>
+                    <newvalue>badConnect</newvalue>
+                </mapping>
+                <mapping>
+                    <value>10</value>
+                    <newvalue>overheating</newvalue>
+                </mapping>
+                <mapping>
+                    <value>11</value>
+                    <newvalue>shutdown</newvalue>
+                </mapping>
+                <mapping>
+                    <value>12</value>
+                    <newvalue>expanding</newvalue>
+                </mapping>
+                <mapping>
+                    <value>13</value>
+                    <newvalue>notAvailable</newvalue>
+                </mapping>
+                <mapping>
+                    <value>14</value>
+                    <newvalue>queuedForExpansion</newvalue>
+                </mapping>
+                <mapping>
+                    <value>15</value>
+                    <newvalue>multipathAccessDegraded</newvalue>
+                </mapping>
+                <mapping>
+                    <value>16</value>
+                    <newvalue>erasing</newvalue>
+                </mapping>
+                <mapping>
+                    <value>17</value>
+                    <newvalue>predictiveSpareRebuildReady</newvalue>
+                </mapping>
+                <mapping>
+                    <value>18</value>
+                    <newvalue>rapidParityInitInProgress</newvalue>
+                </mapping>
+                <mapping>
+                    <value>19</value>
+                    <newvalue>rapidParityInitPending</newvalue>
+                </mapping>
+                <mapping>
+                    <value>20</value>
+                    <newvalue>noAccessEncryptedNoCntlrKey</newvalue>
+                </mapping>
+                <mapping>
+                    <value>21</value>
+                    <newvalue>unencryptedToEncryptedInProgress</newvalue>
+                </mapping>
+                <mapping>
+                    <value>22</value>
+                    <newvalue>newLogDrvKeyRekeyInProgress</newvalue>
+                </mapping>
+                <mapping>
+                    <value>23</value>
+                    <newvalue>noAccessEncryptedCntlrEncryptnNotEnbld</newvalue>
+                </mapping>
+                <mapping>
+                    <value>24</value>
+                    <newvalue>unencryptedToEncryptedNotStarted</newvalue>
+                </mapping>
+                <mapping>
+                    <value>25</value>
+                    <newvalue>newLogDrvKeyRekeyRequestReceived</newvalue>
+                </mapping>
+            </mappings>
+        </value_map>
+        <value_map>
+            <name>CPQIDA-MIB::cpqDaPhyDrvMediaType</name>
+            <mappings>
+                <mapping>
+                    <value>1</value>
+                    <newvalue>Other</newvalue>
+                </mapping>
+                <mapping>
+                    <value>2</value>
+                    <newvalue>rotatingPlatters</newvalue>
+                </mapping>
+                <mapping>
+                    <value>3</value>
+                    <newvalue>solidState</newvalue>
+                </mapping>
+            </mappings>
+        </value_map>
+        <value_map>
+            <name>CPQIDA-MIB::cpqDaPhyDrvSmartStatus</name>
+            <mappings>
+                <mapping>
+                    <value>1</value>
+                    <newvalue>other</newvalue>
+                </mapping>
+                <mapping>
+                    <value>2</value>
+                    <newvalue>OK</newvalue>
+                </mapping>
+                <mapping>
+                    <value>3</value>
+                    <newvalue>replaceDrive</newvalue>
+                </mapping>
+                <mapping>
+                    <value>4</value>
+                    <newvalue>replaceDriveSSDWearOut</newvalue>
+                </mapping>
+            </mappings>
+        </value_map>
+        <value_map>
+            <name>CPQIDA-MIB::cpqDaPhyDrvSSDWearStatus</name>
+            <mappings>
+                <mapping>
+                    <value>1</value>
+                    <newvalue>other</newvalue>
+                </mapping>
+                <mapping>
+                    <value>2</value>
+                    <newvalue>ok</newvalue>
+                </mapping>
+                <mapping>
+                    <value>3</value>
+                    <newvalue>fiftySixDayThreshold</newvalue>
+                </mapping>
+                <mapping>
+                    <value>4</value>
+                    <newvalue>fivePercentThreshold</newvalue>
+                </mapping>
+                <mapping>
+                    <value>5</value>
+                    <newvalue>twoPercentThreshold</newvalue>
+                </mapping>
+                <mapping>
+                    <value>6</value>
+                    <newvalue>ssdWearOut</newvalue>
+                </mapping>
+            </mappings>
+        </value_map>
+        <value_map>
+            <name>CPQIDA-MIB::cpqDaPhyDrvStatus</name>
+            <mappings>
+                <mapping>
+                    <value>1</value>
+                    <newvalue>other</newvalue>
+                </mapping>
+                <mapping>
+                    <value>2</value>
+                    <newvalue>OK</newvalue>
+                </mapping>
+                <mapping>
+                    <value>3</value>
+                    <newvalue>failed</newvalue>
+                </mapping>
+                <mapping>
+                    <value>4</value>
+                    <newvalue>predictiveFailure</newvalue>
+                </mapping>
+            </mappings>
+        </value_map>
+        <value_map>
+            <name>CPQIDA-MIB::cpqDaPhyDrvType</name>
+            <mappings>
+                <mapping>
+                    <value>1</value>
+                    <newvalue>other</newvalue>
+                </mapping>
+                <mapping>
+                    <value>2</value>
+                    <newvalue>parallelScsi</newvalue>
+                </mapping>
+                <mapping>
+                    <value>3</value>
+                    <newvalue>sata</newvalue>
+                </mapping>
+                <mapping>
+                    <value>4</value>
+                    <newvalue>sas</newvalue>
+                </mapping>
+            </mappings>
+        </value_map>
+        <value_map>
+            <name>CPQSINFO-MIB::cpqSiFormFactor</name>
+            <mappings>
+                <mapping>
+                    <value>1</value>
+                    <newvalue>unknown</newvalue>
+                </mapping>
+                <mapping>
+                    <value>2</value>
+                    <newvalue>portable</newvalue>
+                </mapping>
+                <mapping>
+                    <value>3</value>
+                    <newvalue>laptop</newvalue>
+                </mapping>
+                <mapping>
+                    <value>4</value>
+                    <newvalue>desktop</newvalue>
+                </mapping>
+                <mapping>
+                    <value>5</value>
+                    <newvalue>tower</newvalue>
+                </mapping>
+                <mapping>
+                    <value>6</value>
+                    <newvalue>minitower</newvalue>
+                </mapping>
+                <mapping>
+                    <value>7</value>
+                    <newvalue>rackmount</newvalue>
+                </mapping>
+            </mappings>
+        </value_map>
+        <value_map>
+            <name>CPQSINFO-MIB::status</name>
+            <mappings>
+                <mapping>
+                    <value>1</value>
+                    <newvalue>other</newvalue>
+                </mapping>
+                <mapping>
+                    <value>2</value>
+                    <newvalue>ok</newvalue>
+                </mapping>
+                <mapping>
+                    <value>3</value>
+                    <newvalue>degraded</newvalue>
+                </mapping>
+                <mapping>
+                    <value>4</value>
+                    <newvalue>failed</newvalue>
+                </mapping>
+            </mappings>
+        </value_map>
+    </value_maps>
 </zabbix_export>


### PR DESCRIPTION
  retrieves min/max for temps, power supply inventory, memory, etc..
  add model numbers to all parts, replacement model numbers, serial numbers, etc..

It might be wise to import yourself and adjust to zabbix template standards, I have <type>SNMP_AGENT</type> while yours is <type>SNMPv2</type>. I pulled this from Zabbix Server 5.0.

These additions/changes are needed and enhance the data coming into Zabbix

Thanks!
Jason